### PR TITLE
Refactored language file.

### DIFF
--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -246,7 +246,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>(?&lt;!\w)((?i:begin|break|catch|continue|data|define|do|dynamicparam|else|elseif|end|exit|finally|for|foreach(?!-object)|from|if|in|inlinescript|parallel|param|process|return|switch|throw|trap|try|until|using|var|where(?!=-object)|while)|%|\?)(?!\w)</string>
+			<string>(?&lt;!\w)((?i:begin|break|catch|continue|data|define|do|dynamicparam|else|elseif|end|enum|exit|finally|for|foreach(?!-object)|from|if|in|inlinescript|parallel|param|process|return|switch|throw|trap|try|until|using|var|where(?!=-object)|while)|%|\?)(?!\w)</string>
 			<key>name</key>
 			<string>keyword.control.powershell</string>
 		</dict>

--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -14,25 +14,166 @@
 	<array>
 		<dict>
 			<key>begin</key>
-			<string>&lt;#</string>
+			<string>(--%)</string>
 			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.operator.powershell</string>
+				</dict>
+			</dict>
+			<key>comment</key>
+			<string>Stop Parsing</string>
+			<key>end</key>
+			<string>$</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#lineComment</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>(.)</string>
+					<key>name</key>
+					<string>support.other.powershell</string>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#illegalBacktick</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#lineComment</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#blockComment</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#stringDoubleQuoted</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#stringSingleQuoted</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#stringDoubleQuotedHeredoc</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#stringSingleQuotedHeredoc</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#scriptBlock</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#subExpression</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#arrayDeclaration</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#redirection</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#numericConstant</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#operators</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#type</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#function</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#class</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#reservedWords</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#controlWords</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#commands-OLD</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#commands-NEW</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#executableFiles</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#parameter-OLD</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#illegalVariable</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#variable</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#demoScopeHighlighting</string>
+		</dict>
+	</array>
+	<key>repository</key>
+	<dict>
+		<key>arrayDeclaration</key>
+		<dict>
+			<key>begin</key>
+			<string>(\@?\()</string>
+			<key>captures</key>
 			<dict>
 				<key>0</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.start.definition.comment.block.powershell</string>
+					<string>keyword.other.powershell</string>
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>#&gt;</string>
-			<key>endCaptures</key>
-			<dict>
-				<key>0</key>
+			<string>(\))</string>
+			<key>name</key>
+			<string>meta.array.powershell</string>
+			<key>patterns</key>
+			<array>
 				<dict>
-					<key>name</key>
-					<string>punctuation.end.definition.comment.block.powershell</string>
+					<key>include</key>
+					<string>$self</string>
 				</dict>
-			</dict>
+			</array>
+		</dict>
+		<key>blockComment</key>
+		<dict>
+			<key>begin</key>
+			<string>(&lt;#)</string>
+			<key>end</key>
+			<string>(#&gt;)</string>
 			<key>name</key>
 			<string>comment.block.powershell</string>
 			<key>patterns</key>
@@ -43,233 +184,7 @@
 				</dict>
 			</array>
 		</dict>
-		<dict>
-			<key>begin</key>
-			<string>--%</string>
-			<key>beginCaptures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>keyword.control.powershell</string>
-				</dict>
-			</dict>
-			<key>comment</key>
-			<string>Stop Parsing</string>
-			<key>contentName</key>
-			<string>source.powershell</string>
-			<key>end</key>
-			<string>$</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>#lineComment</string>
-				</dict>
-			</array>
-		</dict>
-		<dict>
-			<key>include</key>
-			<string>#lineComment</string>
-		</dict>
-		<dict>
-			<key>match</key>
-			<string>(`(?!$))</string>
-			<key>name</key>
-			<string>invalid.illegal.powershell</string>
-		</dict>
-		<dict>
-			<key>match</key>
-			<string>[2-6]&gt;&amp;1|&gt;&gt;|&gt;|&lt;&lt;|&lt;|&gt;|&gt;\||[1-6]&gt;|[1-6]&gt;&gt;</string>
-			<key>name</key>
-			<string>keyword.operator.redirection.powershell</string>
-		</dict>
-		<dict>
-			<key>include</key>
-			<string>#commands</string>
-		</dict>
-		<dict>
-			<key>include</key>
-			<string>#variable</string>
-		</dict>
-		<dict>
-			<key>include</key>
-			<string>#interpolatedStringContent</string>
-		</dict>
-		<dict>
-			<key>include</key>
-			<string>#function</string>
-		</dict>
-		<dict>
-			<key>include</key>
-			<string>#attribute</string>
-		</dict>
-		<dict>
-			<key>include</key>
-			<string>#type</string>
-		</dict>
-		<dict>
-			<key>begin</key>
-			<string>(?&lt;!(?&lt;!`)")"</string>
-			<key>end</key>
-			<string>"(?!")</string>
-			<key>name</key>
-			<string>string.quoted.double.powershell</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>#variableNoProperty</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#doubleQuotedStringEscapes</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#interpolation</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>`\s*$</string>
-					<key>name</key>
-					<string>keyword.other.powershell</string>
-				</dict>
-			</array>
-		</dict>
-		<dict>
-			<key>comment</key>
-			<string>Needed to parse stuff correctly in 'argument mode'. (See about_parsing.)</string>
-			<key>include</key>
-			<string>#doubleQuotedStringEscapes</string>
-		</dict>
-		<dict>
-			<key>begin</key>
-			<string>(?&lt;!')'</string>
-			<key>end</key>
-			<string>'(?!')</string>
-			<key>name</key>
-			<string>string.quoted.single.powershell</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>match</key>
-					<string>''</string>
-					<key>name</key>
-					<string>constant.character.escape.powershell</string>
-				</dict>
-			</array>
-		</dict>
-		<dict>
-			<key>begin</key>
-			<string>\@"(?=$)</string>
-			<key>end</key>
-			<string>^"@</string>
-			<key>name</key>
-			<string>string.quoted.double.heredoc.powershell</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>#variableNoProperty</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#doubleQuotedStringEscapes</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#interpolation</string>
-				</dict>
-			</array>
-		</dict>
-		<dict>
-			<key>begin</key>
-			<string>\@'(?=$)</string>
-			<key>end</key>
-			<string>^'@</string>
-			<key>name</key>
-			<string>string.quoted.single.heredoc.powershell</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>match</key>
-					<string>''</string>
-					<key>name</key>
-					<string>constant.character.escape.powershell</string>
-				</dict>
-			</array>
-		</dict>
-		<dict>
-			<key>include</key>
-			<string>#numericConstant</string>
-		</dict>
-		<dict>
-			<key>begin</key>
-			<string>@\(</string>
-			<key>captures</key>
-			<dict>
-				<key>0</key>
-				<dict>
-					<key>name</key>
-					<string>keyword.other.powershell</string>
-				</dict>
-			</dict>
-			<key>end</key>
-			<string>\)</string>
-			<key>name</key>
-			<string>meta.group.array-expression.powershell</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>$self</string>
-				</dict>
-			</array>
-		</dict>
-		<dict>
-			<key>begin</key>
-			<string>\$\(</string>
-			<key>captures</key>
-			<dict>
-				<key>0</key>
-				<dict>
-					<key>name</key>
-					<string>keyword.other.powershell</string>
-				</dict>
-			</dict>
-			<key>comment</key>
-			<string>TODO: move to repo; make recursive.</string>
-			<key>end</key>
-			<string>\)</string>
-			<key>name</key>
-			<string>meta.group.complex.subexpression.powershell</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>$self</string>
-				</dict>
-			</array>
-		</dict>
-		<dict>
-			<key>match</key>
-			<string>(?&lt;!\w)-([ci]?[lg][te]|eq|ne)\b</string>
-			<key>name</key>
-			<string>keyword.operator.logical.powershell</string>
-		</dict>
-		<dict>
-			<key>match</key>
-			<string>(?i:[a-z][a-z0-9]+-?[a-z][a-z0-9]+)(?i:\.(?i:exe|cmd|bat|ps1))</string>
-			<key>name</key>
-			<string>support.function.powershell</string>
-		</dict>
-		<dict>
-			<key>match</key>
-			<string>(?&lt;!\w)((?i:begin|break|catch|continue|data|define|do|dynamicparam|node|else|elseif|end|exit|finally|for|foreach(?!-object)|from|if|in|inlinescript|parallel|param|process|return|switch|throw|trap|try|until|using|var|where(?!=-object)|while)|%|\?)(?!\w)</string>
-			<key>name</key>
-			<string>keyword.control.powershell</string>
-		</dict>
+		<key>class</key>
 		<dict>
 			<key>captures</key>
 			<dict>
@@ -287,146 +202,19 @@
 			<key>comment</key>
 			<string>capture should be entity.name.type, but it doesn't provide a good color in the default schema.</string>
 			<key>match</key>
-			<string>(?&lt;!\w|-)((?i:class|enum)|%|\?)(?:\s)+((?:\p{L}|\d|_|)+)\b</string>
+			<string>(?&lt;!\w|-)(?i:(class|enum))\s+(\w+)\s+</string>
 		</dict>
+		<key>commandParameter</key>
 		<dict>
-			<key>match</key>
-			<string>(?&lt;!\w)-(?i:is(?:not)?|as)\b</string>
-			<key>name</key>
-			<string>keyword.operator.comparison.powershell</string>
-		</dict>
-		<dict>
-			<key>match</key>
-			<string>(?&lt;!\w)-(?i:[ic]?(?:eq|ne|[gl][te]|(?:not)?(?:like|match|contains|in)|replace))(?!\p{L})</string>
-			<key>name</key>
-			<string>keyword.operator.comparison.powershell</string>
-		</dict>
-		<dict>
-			<key>match</key>
-			<string>(?&lt;!\w)-(?i:join|split)(?!\p{L})|!</string>
-			<key>name</key>
-			<string>keyword.operator.unary.powershell</string>
-		</dict>
-		<dict>
-			<key>match</key>
-			<string>(?&lt;!\w)-(?i:and|or|not|xor)(?!\p{L})|!</string>
-			<key>name</key>
-			<string>keyword.operator.logical.powershell</string>
-		</dict>
-		<dict>
-			<key>match</key>
-			<string>(?&lt;!\w)-(?i:band|bor|bnot|bxor|shr|shl)(?!\p{L})</string>
-			<key>name</key>
-			<string>keyword.operator.bitwise.powershell</string>
-		</dict>
-		<dict>
-			<key>match</key>
-			<string>(?&lt;!\w)-(?i:f)(?!\p{L})</string>
-			<key>name</key>
-			<string>keyword.operator.string-format.powershell</string>
-		</dict>
-		<dict>
-			<key>include</key>
-			<string>#parameter</string>
-		</dict>
-		<dict>
-			<key>match</key>
-			<string>[+%*/-]?=|[+/*%-]</string>
-			<key>name</key>
-			<string>keyword.operator.assignment.powershell</string>
-		</dict>
-		<dict>
-			<key>match</key>
-			<string>\|{2}|&amp;{2}|;</string>
-			<key>name</key>
-			<string>keyword.other.statement-separator.powershell</string>
-		</dict>
-		<dict>
-			<key>match</key>
-			<string>&amp;|(?&lt;!\w)\.(?= )|`|,|\|</string>
-			<key>name</key>
-			<string>keyword.operator.other.powershell</string>
-		</dict>
-		<dict>
-			<key>comment</key>
-			<string>This is very imprecise, is there a syntax for 'must come after...' </string>
-			<key>match</key>
-			<string>(?&lt;!\s|^)\.\.(?=\d|\(|\$)</string>
-			<key>name</key>
-			<string>keyword.operator.range.powershell</string>
-		</dict>
-	</array>
-	<key>repository</key>
-	<dict>
-		<key>attribute</key>
-		<dict>
-			<key>begin</key>
-			<string>\[(\p{L}|\.|``\d+)+(?=\()</string>
-			<key>beginCaptures</key>
-			<dict>
-				<key>0</key>
-				<dict>
-					<key>name</key>
-					<string>entity.name.tag</string>
-				</dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>entity.name.tag</string>
-				</dict>
-			</dict>
-			<key>end</key>
-			<string>\]</string>
-			<key>endCaptures</key>
-			<dict>
-				<key>0</key>
-				<dict>
-					<key>name</key>
-					<string>entity.name.tag</string>
-				</dict>
-			</dict>
 			<key>patterns</key>
 			<array>
 				<dict>
-					<key>begin</key>
-					<string>\(</string>
-					<key>end</key>
-					<string>\)</string>
+					<key>comment</key>
+					<string>-Parameter value</string>
+					<key>match</key>
+					<string>(-\w+)(:)?</string>
 					<key>name</key>
-					<string>entity.other.attribute-name</string>
-					<key>patterns</key>
-					<array>
-						<dict>
-							<key>captures</key>
-							<dict>
-								<key>0</key>
-								<dict>
-									<key>name</key>
-									<string>entity.other.attribute.parameter.powershell</string>
-								</dict>
-								<key>1</key>
-								<dict>
-									<key>name</key>
-									<string>constant.language.powershell</string>
-								</dict>
-								<key>2</key>
-								<dict>
-									<key>name</key>
-									<string>variable.other.powershell</string>
-								</dict>
-							</dict>
-							<key>comment</key>
-							<string>really we should match the known attributes first</string>
-							<key>match</key>
-							<string>(\w+)\s*=?([^"']*?|'[^']*?'|"[^"]*?")?(?=,|\))</string>
-							<key>name</key>
-							<string>entity.other.attribute-name.powershell</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>$self</string>
-						</dict>
-					</array>
+					<string>variable.parameter.powershell</string>
 				</dict>
 			</array>
 		</dict>
@@ -436,19 +224,90 @@
 			<array>
 				<dict>
 					<key>comment</key>
-					<string>Verb-Noun pattern:</string>
+					<string>Generic function match based on Verb-Noun pair using list of approved verbs.</string>
 					<key>match</key>
-					<string>(?:(\p{L}|\d|_|-|\\|\:)*\\)?\b(?i:Add|Approve|Assert|Backup|Block|Checkpoint|Clear|Close|Compare|Complete|Compress|Confirm|Connect|Convert|ConvertFrom|ConvertTo|Copy|Debug|Deny|Disable|Disconnect|Dismount|Edit|Enable|Enter|Exit|Expand|Export|Find|Format|Get|Grant|Group|Hide|Import|Initialize|Install|Invoke|Join|Limit|Lock|Measure|Merge|Mount|Move|New|Open|Optimize|Out|Ping|Pop|Protect|Publish|Push|Read|Receive|Redo|Register|Remove|Rename|Repair|Request|Reset|Resize|Resolve|Restart|Restore|Resume|Revoke|Save|Search|Select|Send|Set|Show|Skip|Split|Start|Step|Stop|Submit|Suspend|Switch|Sync|Test|Trace|Unblock|Undo|Uninstall|Unlock|Unprotect|Unpublish|Unregister|Update|Use|Wait|Watch|Write)\-.+?(?:\.(?i:exe|cmd|bat|ps1))?\b</string>
+					<string>(?&lt;!\\)\b(?i:Add|Approve|Assert|Backup|Block|Checkpoint|Clear|Close|Compare|Complete|Compress|Confirm|Connect|Convert|ConvertFrom|ConvertTo|Copy|Debug|Deny|Disable|Disconnect|Dismount|Edit|Enable|Enter|Exit|Expand|Export|Find|Format|Get|Grant|Group|Hide|Import|Initialize|Install|Invoke|Join|Limit|Lock|Measure|Merge|Mount|Move|New|Open|Optimize|Out|Ping|Pop|Protect|Publish|Push|Read|Receive|Redo|Register|Remove|Rename|Repair|Request|Reset|Resize|Resolve|Restart|Restore|Resume|Revoke|Save|Search|Select|Send|Set|Show|Skip|Split|Start|Step|Stop|Submit|Suspend|Switch|Sync|Test|Trace|Unblock|Undo|Uninstall|Unlock|Unprotect|Unpublish|Unregister|Update|Use|Wait|Watch|Write)-(?i:\w+)\b(?!\.|\\)</string>
 					<key>name</key>
 					<string>support.function.powershell</string>
 				</dict>
 				<dict>
 					<key>comment</key>
-					<string>Builtin cmdlets with reserved verbs</string>
+					<string>Built-in commands that don't adhere to the approved verbs standard.</string>
 					<key>match</key>
-					<string>(?&lt;!\w)(?i:foreach-object)(?!\w)</string>
+					<string>(?&lt;!\\)\b(?i:foreach-object|tee-object|where-object|sort-object)\b(?!\.|\\)</string>
 					<key>name</key>
 					<string>support.function.powershell</string>
+				</dict>
+				<dict>
+					<key>comment</key>
+					<string>Built-in aliases</string>
+					<key>match</key>
+					<string>(?&lt;!\\|\[)\b(?i:ac|asnp|cat|cd|cfs|chdir|clc|clear|clhy|cli|clp|cls|clv|cnsn|compare|copy|cp|cpi|cpp|curl|cvpa|dbp|del|diff|dir|dnsn|ebp|echo|epal|epcsv|epsn|erase|etsn|exsn|fc|fhx|fl|ft|fw|gal|gbp|gc|gcb|gci|gcm|gcs|gdr|ghy|gi|gjb|gl|gm|gmo|gp|gps|gpv|group|gsn|gsnp|gsv|gu|gv|gwmi|h|history|icm|iex|ihy|ii|ipal|ipcsv|ipmo|ipsn|irm|ise|iwmi|iwr|kill|lp|ls|man|md|measure|mi|mount|move|mp|mv|nal|ndr|ni|nmo|npssc|nsn|nv|ogv|oh|popd|ps|pushd|r|rbp|rcjb|rcsn|rd|rdr|ren|ri|rjb|rm|rmdir|rmo|rni|rnp|rp|rsn|rsnp|rujb|rv|rvpa|rwmi|sajb|sal|saps|sasv|sbp|sc|scb|select|set|shcm|si|sl|sleep|sls|sort|sp|spjb|spps|spsv|start|sujb|sv|swmi|tee|trcm|type|wget|wjb|write)\b(?!\.|\\|\])</string>
+					<key>name</key>
+					<string>support.other.alias.powershell</string>
+				</dict>
+			</array>
+		</dict>
+		<key>commands-NEW</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>begin</key>
+					<string>\b((?i:(Invoke))-(\w+))\b</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>support.function.powershell</string>
+						</dict>
+					</dict>
+					<key>comment</key>
+					<string>Verb-Noun</string>
+					<key>end</key>
+					<string>((?=\))|(?&lt;!`)\n|(?&lt;!`)\r|\|)</string>
+					<key>name</key>
+					<string>meta.command.powershell</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>#commandParameter</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#lineComment</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#numericConstant</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#variable</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#stringDoubleQuoted</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#stringSingleQuoted</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#arrayDeclaration</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#illegalBacktick</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#illegalVariable</string>
+						</dict>
+					</array>
 				</dict>
 			</array>
 		</dict>
@@ -513,30 +372,264 @@
 							<string>constant.string.documentation.powershell</string>
 						</dict>
 					</dict>
+					<key>comment</key>
+					<string>Requires -Version</string>
 					<key>match</key>
-					<string>((?i:requires))\s+-(Version\s+\d(?:.\d+)?|Assembly\s+(?:.*)|Module\s+(?:.*)|PsSnapIn\s+(?:.*)|ShellId\s+(?:.*))</string>
+					<string>(?i:(requires))\s(-(?i:version)\s\d+(\.\d+)?)</string>
+					<key>name</key>
+					<string>comment.documentation.embedded.powershell</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.operator.documentation.powershell</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>constant.string.documentation.powershell</string>
+						</dict>
+					</dict>
+					<key>comment</key>
+					<string>Requires -PSSnapin</string>
+					<key>match</key>
+					<string>(?i:(requires))\s(-(?i:pssnapin)\s\w+(\s*-(?i:version)\s\d+(\.\d+)?)?)</string>
+					<key>name</key>
+					<string>comment.documentation.embedded.powershell</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.operator.documentation.powershell</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>constant.string.documentation.powershell</string>
+						</dict>
+					</dict>
+					<key>comment</key>
+					<string>Requires -Modules</string>
+					<key>match</key>
+					<string>(?i:(requires))\s(-(?i:modules)\s.*)</string>
+					<key>name</key>
+					<string>comment.documentation.embedded.powershell</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.operator.documentation.powershell</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>constant.string.documentation.powershell</string>
+						</dict>
+					</dict>
+					<key>comment</key>
+					<string>Requires -ShellId</string>
+					<key>match</key>
+					<string>(?i:(requires))\s(-(?i:shellid)\s.*)</string>
+					<key>name</key>
+					<string>comment.documentation.embedded.powershell</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.operator.documentation.powershell</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>constant.string.documentation.powershell</string>
+						</dict>
+					</dict>
+					<key>comment</key>
+					<string>Requires -RunAsAdministrator</string>
+					<key>match</key>
+					<string>(?i:(requires))\s(-(?i:runasadministrator))</string>
 					<key>name</key>
 					<string>comment.documentation.embedded.powershell</string>
 				</dict>
 			</array>
 		</dict>
-		<key>doubleQuotedStringEscapes</key>
+		<key>controlWords</key>
+		<dict>
+			<key>match</key>
+			<string>(\b(?&lt;!-|\$)(?i:begin|exit|break|return|catch|finally|for|continue|foreach|throw|from|trap|try|do|if|until|in|using|else|elseif|while|end|where)\b(?!-|\.))</string>
+			<key>name</key>
+			<string>keyword.control.powershell</string>
+		</dict>
+		<key>demoScopeHighlighting</key>
 		<dict>
 			<key>patterns</key>
 			<array>
 				<dict>
 					<key>match</key>
-					<string>`[0abnfrvt"'$`]</string>
+					<string>\b(demo_scope_constantLanguage)\b</string>
 					<key>name</key>
-					<string>constant.character.escape.powershell</string>
+					<string>constant.language</string>
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>""</string>
+					<string>\b(demo_scope_constantNumeric)\b</string>
 					<key>name</key>
-					<string>constant.character.escape.powershell</string>
+					<string>constant.numeric</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\b(demo_scope_constantOther)\b</string>
+					<key>name</key>
+					<string>constant.other</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\b(demo_scope_constantCharacterEscape)\b</string>
+					<key>name</key>
+					<string>constant.character.escape</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\b(demo_scope_entityOtherAttributeName)\b</string>
+					<key>name</key>
+					<string>entity.other.attribute-name</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\b(demo_scope_invalid)\b</string>
+					<key>name</key>
+					<string>invalid</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\b(demo_scope_comment)\b</string>
+					<key>name</key>
+					<string>comment</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\b(demo_scope_metaSelector)\b</string>
+					<key>name</key>
+					<string>meta.selector</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\b(demo_scope_storageType)\b</string>
+					<key>name</key>
+					<string>storage.type</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\b(demo_scope_string)\b</string>
+					<key>name</key>
+					<string>string</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\b(demo_scope_keywordControl)\b</string>
+					<key>name</key>
+					<string>keyword.control</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\b(demo_scope_keywordOperator)\b</string>
+					<key>name</key>
+					<string>keyword.operator</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\b(demo_scope_keywordOtherUnit)\b</string>
+					<key>name</key>
+					<string>keyword.other.unit</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\b(demo_scope_supportType)\b</string>
+					<key>name</key>
+					<string>support.type</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\b(demo_scope_supportConstant)\b</string>
+					<key>name</key>
+					<string>support.constant</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\b(demo_scope_supportVariable)\b</string>
+					<key>name</key>
+					<string>support.variable</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\b(demo_scope_entityNameClass)\b</string>
+					<key>name</key>
+					<string>entity.name.class</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\b(demo_scope_entityNameType)\b</string>
+					<key>name</key>
+					<string>entity.name.type</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\b(demo_scope_entityNameFunction)\b</string>
+					<key>name</key>
+					<string>entity.name.function</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\b(demo_scope_metaParameterTypeVariable)\b</string>
+					<key>name</key>
+					<string>meta.parameter.type.variable</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\b(demo_scope_metaTypeAnnotation)\b</string>
+					<key>name</key>
+					<string>meta.type.annotation</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\b(demo_scope_variableParameter)\b</string>
+					<key>name</key>
+					<string>variable.parameter</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\b(demo_scope_variableLanguage)\b</string>
+					<key>name</key>
+					<string>variable.language</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\b(demo_scope_variableOther)\b</string>
+					<key>name</key>
+					<string>variable.other</string>
 				</dict>
 			</array>
+		</dict>
+		<key>executableFiles</key>
+		<dict>
+			<key>comment</key>
+			<string>Executable files, like exe, com, ps1, cmd and bat</string>
+			<key>match</key>
+			<string>(\b(([A-Za-z0-9\-_\.]+).(?i:exe|com|ps1|cmd|bat))\b)</string>
+			<key>name</key>
+			<string>support.function.powershell</string>
 		</dict>
 		<key>function</key>
 		<dict>
@@ -575,90 +668,44 @@
 				</dict>
 			</array>
 		</dict>
-		<key>interpolatedStringContent</key>
+		<key>hashTable</key>
 		<dict>
 			<key>begin</key>
-			<string>\(</string>
-			<key>beginCaptures</key>
-			<dict>
-				<key>0</key>
-				<dict>
-					<key>name</key>
-					<string>keyword.other.powershell</string>
-				</dict>
-			</dict>
-			<key>contentName</key>
-			<string>interpolated.simple.source.powershell</string>
+			<string>(@\{)</string>
 			<key>end</key>
-			<string>\)</string>
-			<key>endCaptures</key>
-			<dict>
-				<key>0</key>
-				<dict>
-					<key>name</key>
-					<string>keyword.other.powershell</string>
-				</dict>
-			</dict>
+			<string>(\})</string>
+			<key>name</key>
+			<string>meta.hashtable.powershell</string>
 			<key>patterns</key>
 			<array>
 				<dict>
 					<key>include</key>
 					<string>$self</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#interpolation</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#interpolatedStringContent</string>
 				</dict>
 			</array>
 		</dict>
-		<key>interpolation</key>
+		<key>illegalBacktick</key>
 		<dict>
-			<key>begin</key>
-			<string>(\$)\(</string>
-			<key>beginCaptures</key>
-			<dict>
-				<key>0</key>
-				<dict>
-					<key>name</key>
-					<string>keyword.other.powershell</string>
-				</dict>
-			</dict>
-			<key>contentName</key>
-			<string>interpolated.complex.source.powershell</string>
-			<key>end</key>
-			<string>\)</string>
-			<key>endCaptures</key>
-			<dict>
-				<key>0</key>
-				<dict>
-					<key>name</key>
-					<string>keyword.other.powershell</string>
-				</dict>
-			</dict>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>$self</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#interpolation</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#interpolatedStringContent</string>
-				</dict>
-			</array>
+			<key>comment</key>
+			<string>Any characters (other than new line) after a back-tick, is illegal in PowerShell.</string>
+			<key>match</key>
+			<string>(`(?!$))</string>
+			<key>name</key>
+			<string>invalid.illegal.powershell</string>
+		</dict>
+		<key>illegalVariable</key>
+		<dict>
+			<key>match</key>
+			<string>\$\w+:\s</string>
+			<key>name</key>
+			<string>invalid.illegal.powershell</string>
 		</dict>
 		<key>lineComment</key>
 		<dict>
 			<key>begin</key>
-			<string>(?&lt;![\\-])(?:\s+?|^)#</string>
+			<string>(^#|\s#)</string>
+			<key>comment</key>
+			<string>Line comment - must start with new line or at least one whitespace character before the '#'.</string>
 			<key>end</key>
 			<string>$</string>
 			<key>name</key>
@@ -676,62 +723,154 @@
 			<key>patterns</key>
 			<array>
 				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.operator.math.powershell</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>support.constant.powershell</string>
-						</dict>
-						<key>3</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.other.powershell</string>
-						</dict>
-					</dict>
+					<key>comment</key>
+					<string>Real [(+|-)] digits . digits [e [(+|-)] digits] [(d|l)] [(kb|mb|gb|tb|pb)]</string>
 					<key>match</key>
-					<string>(?&lt;!\w)(?i:(0x)([a-f0-9]+)((?i:L)?(?i:[kmgtp]b)?))(?!\w)</string>
+					<string>(?&lt;!\w)([-+]?)\d+\.\d+(?i:e(\+|-){0,1}\d+){0,1}(?i:d|l){0,1}(?i:kb|mb|gb|tb|pb){0,1}(?!\w|\d)</string>
+					<key>name</key>
+					<string>constant.numeric.real.powershell</string>
+				</dict>
+				<dict>
+					<key>comment</key>
+					<string>Real [(+|-)] . digits [e [(+|-)] digits] [(d|l)] [(kb|mb|gb|tb|pb)]</string>
+					<key>match</key>
+					<string>(?&lt;!\.|\d|\w)([-+]?)\.\d+(?i:e(\+|-){0,1}\d+){0,1}(?i:d|l){0,1}(?i:kb|mb|gb|tb|pb){0,1}(?!\w|\d)</string>
+					<key>name</key>
+					<string>constant.numeric.real.powershell</string>
+				</dict>
+				<dict>
+					<key>comment</key>
+					<string>Real [(+|-)] digits . [e [(+|-)] digits] [(d|l)] [(kb|mb|gb|tb|pb)]</string>
+					<key>match</key>
+					<string>(?&lt;!\w)([-+]?)(?&lt;!\d)\d+\.(?i:e(\+|-){0,1}\d+){0,1}(?i:d|l){0,1}(?i:kb|mb|gb|tb|pb){0,1}(?!\w|\d|\.)</string>
+					<key>name</key>
+					<string>constant.numeric.real.powershell</string>
+				</dict>
+				<dict>
+					<key>comment</key>
+					<string>Integer [(+|-)] digits [(d|l)] [(kb|mb|gb|tb|pb)]</string>
+					<key>match</key>
+					<string>(?&lt;!\w|\w\.)([-+]?)\d+(?i:d|l){0,1}(?i:kb|mb|gb|tb|pb){0,1}(?!\w|\d)</string>
+					<key>name</key>
+					<string>constant.numeric.integer.powershell</string>
+				</dict>
+				<dict>
+					<key>comment</key>
+					<string>Real [(+|-)] digits [e [(+|-)] digits] [(d|l)] [(kb|mb|gb|tb|pb)]</string>
+					<key>match</key>
+					<string>(?&lt;!\w|\.)([-+]?)(?&lt;!\d)\d+(?i:e(\+|-){0,1}\d+){0,1}(?i:d|l){0,1}(?i:kb|mb|gb|tb|pb){0,1}(?!\w|\d|\.)</string>
+					<key>name</key>
+					<string>constant.numeric.real.powershell</string>
+				</dict>
+				<dict>
+					<key>comment</key>
+					<string>Hexadecimal 0x 0-f [l] [kb|mb|gb|tb|pb]</string>
+					<key>match</key>
+					<string>(?&lt;!\w|\d)([-+]?)(?i:0x)(?i:[0-9a-f])+(?i:l){0,1}(?i:kb|mb|gb|tb|pb){0,1}(?!\w|\d)</string>
 					<key>name</key>
 					<string>constant.numeric.hexadecimal.powershell</string>
 				</dict>
+			</array>
+		</dict>
+		<key>operators</key>
+		<dict>
+			<key>patterns</key>
+			<array>
 				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>support.constant.powershell</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.operator.math.powershell</string>
-						</dict>
-						<key>3</key>
-						<dict>
-							<key>name</key>
-							<string>support.constant.powershell</string>
-						</dict>
-						<key>4</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.other.powershell</string>
-						</dict>
-						<key>5</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.other.powershell</string>
-						</dict>
-					</dict>
+					<key>comment</key>
+					<string>Comparison</string>
 					<key>match</key>
-					<string>(?&lt;!\w)(?i:(\d*\.?\d+)(?:((?i:E)[+-]?)(\d+))?((?i:[DL])?)((?i:[kmgtp]b)?))(?!\w)</string>
+					<string>(?&lt;=\d|\s|^)-(?i:as|is|isnot|in|notin|join|((c|i)?(eq|ne|gt|lt|ge|le|like|notlike|split|replace|contains|notcontains|match|notmatch))|shl|shr)\b(?!\.|\\)</string>
 					<key>name</key>
-					<string>constant.numeric.scientific.powershell</string>
+					<string>keyword.operator.comparison.powershell</string>
+				</dict>
+				<dict>
+					<key>comment</key>
+					<string>Bitwise</string>
+					<key>match</key>
+					<string>(?&lt;=\d|\s|^)-(?i:band|bor|bxor|bnot|shr|shl)\b</string>
+					<key>name</key>
+					<string>keyword.operator.bitwise.powershell</string>
+				</dict>
+				<dict>
+					<key>comment</key>
+					<string>Logical</string>
+					<key>match</key>
+					<string>(?&lt;=\d|\s|^)-(?i:and|or|xor)\b</string>
+					<key>name</key>
+					<string>keyword.operator.logical.powershell</string>
+				</dict>
+				<dict>
+					<key>comment</key>
+					<string>Format</string>
+					<key>match</key>
+					<string>(?&lt;=\d|\s|^)-(?i:f)\b</string>
+					<key>name</key>
+					<string>keyword.operator.format.powershell</string>
+				</dict>
+				<dict>
+					<key>comment</key>
+					<string>Assignment</string>
+					<key>match</key>
+					<string>(=|-=|\+=|\*=|/=|%=)</string>
+					<key>name</key>
+					<string>keyword.operator.assignment.powershell</string>
+				</dict>
+				<dict>
+					<key>comment</key>
+					<string>Logical NOT</string>
+					<key>match</key>
+					<string>(?&lt;=\d|\s|^)((?i:-not)|!)</string>
+					<key>name</key>
+					<string>keyword.operator.unary.logical-not.powershell</string>
+				</dict>
+				<dict>
+					<key>comment</key>
+					<string>Multiplicative</string>
+					<key>match</key>
+					<string>([*/%])(?!\.)</string>
+					<key>name</key>
+					<string>keyword.operator.multiplicative.powershell</string>
+				</dict>
+				<dict>
+					<key>comment</key>
+					<string>Unary Plus</string>
+					<key>match</key>
+					<string>([+](?=\$|\(|"))</string>
+					<key>name</key>
+					<string>keyword.operator.unary-plus.powershell</string>
+				</dict>
+				<dict>
+					<key>comment</key>
+					<string>Unary Minus</string>
+					<key>match</key>
+					<string>([-](?=\$|\(|"))</string>
+					<key>name</key>
+					<string>keyword.operator.unary-minus.powershell</string>
+				</dict>
+				<dict>
+					<key>comment</key>
+					<string>Additive</string>
+					<key>match</key>
+					<string>([+-])(?!\{|\p{L}|@)</string>
+					<key>name</key>
+					<string>keyword.operator.additive.powershell</string>
+				</dict>
+				<dict>
+					<key>comment</key>
+					<string>Range</string>
+					<key>match</key>
+					<string>(\.\.)</string>
+					<key>name</key>
+					<string>keyword.operator.range.powershell</string>
+				</dict>
+				<dict>
+					<key>comment</key>
+					<string>Command invocation (Call)</string>
+					<key>match</key>
+					<string>(&amp;)</string>
+					<key>name</key>
+					<string>keyword.operator.other.powershell</string>
 				</dict>
 			</array>
 		</dict>
@@ -741,6 +880,35 @@
 			<string>((?&lt;=\s)-(\w+))</string>
 			<key>name</key>
 			<string>variable.parameter.powershell</string>
+		</dict>
+		<key>redirection</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>comment</key>
+					<string>Merging redirection</string>
+					<key>match</key>
+					<string>(?&lt;=\s|^)([2-6\*]?&gt;&amp;1)</string>
+					<key>name</key>
+					<string>keyword.operator.redirection.powershell</string>
+				</dict>
+				<dict>
+					<key>comment</key>
+					<string>File redirection</string>
+					<key>match</key>
+					<string>(?&lt;=\s|^)(([1-6\*]?&gt;{1,2})|(&lt;))</string>
+					<key>name</key>
+					<string>keyword.operator.redirection.powershell</string>
+				</dict>
+			</array>
+		</dict>
+		<key>reservedWords</key>
+		<dict>
+			<key>match</key>
+			<string>(\b(?&lt;!-|\$)(?i:configuration|node|process|enum|filter|sequence|class|switch|data|define|function|dynamicparam|inlinescript|var|parallel|param|workflow)\b(?!-|\.))</string>
+			<key>name</key>
+			<string>keyword.other.powershell</string>
 		</dict>
 		<key>scriptblock</key>
 		<dict>
@@ -758,6 +926,153 @@
 				</dict>
 			</array>
 		</dict>
+		<key>stringDoubleQuoted</key>
+		<dict>
+			<key>begin</key>
+			<string>((?&lt;!\")\")</string>
+			<key>end</key>
+			<string>(\"(?!\"))</string>
+			<key>name</key>
+			<string>string.quoted.double.powershell</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#stringEscapeChars</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#illegalVariable</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#variable</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#subExpression</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#scriptBlock</string>
+				</dict>
+			</array>
+		</dict>
+		<key>stringDoubleQuotedHeredoc</key>
+		<dict>
+			<key>begin</key>
+			<string>(\@"\s*$)</string>
+			<key>end</key>
+			<string>^"\@</string>
+			<key>name</key>
+			<string>string.quoted.double.heredoc.powershell</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#stringEscapeChars</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#variable</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#subExpression</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#scriptBlock</string>
+				</dict>
+			</array>
+		</dict>
+		<key>stringEscapeChars</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>(`[0abfnrtv"'$`])</string>
+					<key>name</key>
+					<string>constant.character.escape.powershell</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>("")</string>
+					<key>name</key>
+					<string>constant.character.escape.powershell</string>
+				</dict>
+			</array>
+		</dict>
+		<key>stringSingleQuoted</key>
+		<dict>
+			<key>begin</key>
+			<string>((?&lt;!')')</string>
+			<key>end</key>
+			<string>('(?!'))</string>
+			<key>name</key>
+			<string>string.quoted.single.powershell</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#stringSingleQuotedDouble</string>
+				</dict>
+			</array>
+		</dict>
+		<key>stringSingleQuotedDouble</key>
+		<dict>
+			<key>match</key>
+			<string>('')</string>
+			<key>name</key>
+			<string>constant.character.escape.powershell</string>
+		</dict>
+		<key>stringSingleQuotedHeredoc</key>
+		<dict>
+			<key>begin</key>
+			<string>(\@'\s*$)</string>
+			<key>end</key>
+			<string>^'\@</string>
+			<key>name</key>
+			<string>string.quoted.single.heredoc.powershell</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#stringSingleQuotedDouble</string>
+				</dict>
+			</array>
+		</dict>
+		<key>subExpression</key>
+		<dict>
+			<key>begin</key>
+			<string>(\$\()</string>
+			<key>captures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.other.powershell</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>(\))</string>
+			<key>name</key>
+			<string>meta.subexpression.powershell</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>$self</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>(.)</string>
+					<key>name</key>
+					<string>source.powershell</string>
+				</dict>
+			</array>
+		</dict>
 		<key>type</key>
 		<dict>
 			<key>begin</key>
@@ -767,11 +1082,11 @@
 				<key>0</key>
 				<dict>
 					<key>name</key>
-					<string>entity.other.attribute-name</string>
+					<string>keyword.other.powershell</string>
 				</dict>
 			</dict>
 			<key>comment</key>
-			<string>name should be entity.name.type but default schema doesn't have a good color for it</string>
+			<string>Type []</string>
 			<key>end</key>
 			<string>\]</string>
 			<key>endCaptures</key>
@@ -779,20 +1094,59 @@
 				<key>0</key>
 				<dict>
 					<key>name</key>
-					<string>entity.other.attribute-name</string>
+					<string>keyword.other.powershell</string>
 				</dict>
 			</dict>
 			<key>patterns</key>
 			<array>
 				<dict>
-					<key>match</key>
-					<string>(\p{L}|\.|``\d+)+?</string>
-					<key>name</key>
-					<string>entity.other.attribute-name</string>
+					<key>begin</key>
+					<string>\(</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.other.powershell</string>
+						</dict>
+					</dict>
+					<key>comment</key>
+					<string>Parenthesis ()</string>
+					<key>end</key>
+					<string>\)</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.other.powershell</string>
+						</dict>
+					</dict>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>$self</string>
+						</dict>
+						<dict>
+							<key>comment</key>
+							<string>Reserved words within [( )]</string>
+							<key>match</key>
+							<string>\b(?i)(mandatory|valuefrompipeline|valuefrompipelinebypropertyname|valuefromremainingarguments|position|parametersetname|defaultparametersetname|supportsshouldprocess|positionalbinding|helpuri|confirmimpact)\b</string>
+							<key>name</key>
+							<string>entity.other.attribute-name.powershell</string>
+						</dict>
+					</array>
 				</dict>
 				<dict>
 					<key>include</key>
 					<string>$self</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>(.(`){0,2}(\d){0,2})</string>
+					<key>name</key>
+					<string>entity.name.type</string>
 				</dict>
 			</array>
 		</dict>
@@ -801,122 +1155,20 @@
 			<key>patterns</key>
 			<array>
 				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.other.powershell</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>constant.language.powershell</string>
-						</dict>
-					</dict>
 					<key>comment</key>
-					<string>These are special constants.</string>
+					<string>Invalid variable name</string>
 					<key>match</key>
-					<string>(\$)(?i:(False|Null|True))\b</string>
+					<string>(\$)(\w+-\w+)\b</string>
+					<key>name</key>
+					<string>invalid.illegal.powershell</string>
 				</dict>
 				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.other.powershell</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>support.constant.variable.powershell</string>
-						</dict>
-						<key>3</key>
-						<dict>
-							<key>name</key>
-							<string>entity.name.function.invocation.powershell</string>
-						</dict>
-					</dict>
 					<key>comment</key>
-					<string>These are the other built-in constants.</string>
+					<string>Automatic variables - read-only.</string>
 					<key>match</key>
-					<string>(\$)(?i:(Error|ExecutionContext|Host|Home|PID|PsHome|PsVersionTable|ShellID))((?:\.(?:\p{L}|\d|_)+)*\b)?\b</string>
-				</dict>
-				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.other.powershell</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>support.constant.automatic.powershell</string>
-						</dict>
-						<key>3</key>
-						<dict>
-							<key>name</key>
-							<string>entity.name.function.invocation.powershell</string>
-						</dict>
-					</dict>
-					<key>comment</key>
-					<string>Automatic variables are not constants, but they are read-only. In monokai (default) color schema support.variable doesn't have color, so we use constant.</string>
-					<key>match</key>
-					<string>(\$)(?i:(\$|\^|\?|_|Args|ConsoleFileName|Event|EventArgs|EventSubscriber|ForEach|Input|LastExitCode|Matches|MyInvocation|NestedPromptLevel|Profile|PSBoundParameters|PsCmdlet|PsCulture|PSDebugContext|PSItem|PSCommandPath|PSScriptRoot|PsUICulture|Pwd|Sender|SourceArgs|SourceEventArgs|StackTrace|Switch|This))((?:\.(?:\p{L}|\d|_)+)*\b)?\b</string>
-				</dict>
-				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.other.powershell</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>variable.language.powershell</string>
-						</dict>
-						<key>3</key>
-						<dict>
-							<key>name</key>
-							<string>entity.name.function.invocation.powershell</string>
-						</dict>
-					</dict>
-					<key>comment</key>
-					<string>Style preference variables as language variables so that they stand out.</string>
-					<key>match</key>
-					<string>(\$)(?i:(ConfirmPreference|DebugPreference|ErrorActionPreference|ErrorView|FormatEnumerationLimit|MaximumAliasCount|MaximumDriveCount|MaximumErrorCount|MaximumFunctionCount|MaximumHistoryCount|MaximumVariableCount|OFS|OutputEncoding|ProgressPreference|PsCulture|PSDebugContext|PSDefaultParameterValues|PSEmailServer|PSItem|PSModuleAutoloadingPreference|PSSenderInfo|PSSessionApplicationName|PSSessionConfigurationName|PSSessionOption|VerbosePreference|WarningPreference|WhatIfPreference))((?:\.(?:\p{L}|\d|_)+)*\b)?\b</string>
-				</dict>
-				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.other.powershell</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>storage.modifier.scope.powershell</string>
-						</dict>
-						<key>3</key>
-						<dict>
-							<key>name</key>
-							<string>variable.other.normal.powershell</string>
-						</dict>
-						<key>4</key>
-						<dict>
-							<key>name</key>
-							<string>entity.name.function.invocation.powershell</string>
-						</dict>
-					</dict>
-					<key>match</key>
-					<string>(?i:(\$)(global|local|private|script|using|workflow):((?:\p{L}|\d|_)+))((?:\.(?:\p{L}|\d|_)+)*\b)?</string>
+					<string>(\$)(?i:_|args|consolefilename|error|event|eventsubscriber|executioncontext|false|foreach|home|host|input|lastexitcode|matches|myinvocation|nestedpromptlevel|null|pid|psboundparameters|pscmdlet|psculture|psdebugcontext|pshome|psitem|psscriptroot|psuiculture|psversiontable|pwd|sender|shellid|sourceargs|sourceeventargs|switch|this|true)\b</string>
+					<key>name</key>
+					<string>constant.language.powershell</string>
 				</dict>
 				<dict>
 					<key>captures</key>
@@ -939,100 +1191,13 @@
 						<key>4</key>
 						<dict>
 							<key>name</key>
-							<string>keyword.other.powershell</string>
-						</dict>
-						<key>5</key>
-						<dict>
-							<key>name</key>
-							<string>entity.name.function.invocation.powershell</string>
-						</dict>
-					</dict>
-					<key>match</key>
-					<string>(?i:(\$\{)(global|local|private|script|using|workflow):([^}]*[^}`])(\}))((?:\.(?:\p{L}|\d|_)+)*\b)?</string>
-				</dict>
-				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.other.powershell</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>support.variable.drive.powershell</string>
-						</dict>
-						<key>3</key>
-						<dict>
-							<key>name</key>
 							<string>variable.other.readwrite.powershell</string>
 						</dict>
-						<key>4</key>
-						<dict>
-							<key>name</key>
-							<string>entity.name.function.invocation.powershell</string>
-						</dict>
-					</dict>
-					<key>match</key>
-					<string>(?i:(\$)((?:\p{L}|\d|_)+:)?((?:\p{L}|\d|_)+))((?:\.(?:\p{L}|\d|_)+)*\b)?</string>
-				</dict>
-				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.other.powershell</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>support.variable.drive.powershell</string>
-						</dict>
-						<key>3</key>
-						<dict>
-							<key>name</key>
-							<string>variable.other.readwrite.powershell</string>
-						</dict>
-						<key>4</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.other.powershell</string>
-						</dict>
-						<key>5</key>
-						<dict>
-							<key>name</key>
-							<string>entity.name.function.invocation.powershell</string>
-						</dict>
-					</dict>
-					<key>match</key>
-					<string>(?i:(\$\{)((?:\p{L}|\d|_)+:)?([^}]*[^}`])(\}))((?:\.(?:\p{L}|\d|_)+)*\b)?</string>
-				</dict>
-			</array>
-		</dict>
-		<key>variableNoProperty</key>
-		<dict>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.other.powershell</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>constant.language.powershell</string>
-						</dict>
 					</dict>
 					<key>comment</key>
-					<string>These are special constants.</string>
+					<string>$var, $local:var</string>
 					<key>match</key>
-					<string>(\$)(?i:(False|Null|True))\b</string>
+					<string>(\$)((?i:global|local|script|private|using|env|function|alias|cert|variable|hkcu|hklm|wsman):)?(\w+)(:\w+)?</string>
 				</dict>
 				<dict>
 					<key>captures</key>
@@ -1045,125 +1210,28 @@
 						<key>2</key>
 						<dict>
 							<key>name</key>
-							<string>support.constant.variable.powershell</string>
+							<string>keyword.other.powershell</string>
 						</dict>
 						<key>3</key>
-						<dict>
-							<key>name</key>
-							<string>entity.name.function.invocation.powershell</string>
-						</dict>
-					</dict>
-					<key>comment</key>
-					<string>These are the other built-in constants.</string>
-					<key>match</key>
-					<string>(\$)(?i:(Error|ExecutionContext|Host|Home|PID|PsHome|PsVersionTable|ShellID))\b</string>
-				</dict>
-				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.other.powershell</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>support.variable.automatic.powershell</string>
-						</dict>
-						<key>3</key>
-						<dict>
-							<key>name</key>
-							<string>entity.name.function.invocation.powershell</string>
-						</dict>
-					</dict>
-					<key>comment</key>
-					<string>Automatic variables are not constants, but they are read-only...</string>
-					<key>match</key>
-					<string>(\$)(?i:(\$|\^|\?|_|Args|ConsoleFileName|Event|EventArgs|EventSubscriber|ForEach|Input|LastExitCode|Matches|MyInvocation|NestedPromptLevel|Profile|PSBoundParameters|PsCmdlet|PsCulture|PSDebugContext|PSItem|PSCommandPath|PSScriptRoot|PsUICulture|Pwd|Sender|SourceArgs|SourceEventArgs|StackTrace|Switch|This))\b</string>
-				</dict>
-				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.other.powershell</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>variable.language.powershell</string>
-						</dict>
-						<key>3</key>
-						<dict>
-							<key>name</key>
-							<string>entity.name.function.invocation.powershell</string>
-						</dict>
-					</dict>
-					<key>comment</key>
-					<string>Style preference variables as language variables so that they stand out.</string>
-					<key>match</key>
-					<string>(\$)(?i:(ConfirmPreference|DebugPreference|ErrorActionPreference|ErrorView|FormatEnumerationLimit|MaximumAliasCount|MaximumDriveCount|MaximumErrorCount|MaximumFunctionCount|MaximumHistoryCount|MaximumVariableCount|OFS|OutputEncoding|ProgressPreference|PsCulture|PSDebugContext|PSDefaultParameterValues|PSEmailServer|PSItem|PSModuleAutoloadingPreference|PSSenderInfo|PSSessionApplicationName|PSSessionConfigurationName|PSSessionOption|VerbosePreference|WarningPreference|WhatIfPreference))\b</string>
-				</dict>
-				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.other.powershell</string>
-						</dict>
-						<key>2</key>
 						<dict>
 							<key>name</key>
 							<string>storage.modifier.scope.powershell</string>
 						</dict>
-						<key>3</key>
-						<dict>
-							<key>name</key>
-							<string>variable.other.normal.powershell</string>
-						</dict>
 						<key>4</key>
-						<dict>
-							<key>name</key>
-							<string>entity.name.function.invocation.powershell</string>
-						</dict>
-					</dict>
-					<key>match</key>
-					<string>(?i:(\$)(global|local|private|script|using|workflow):((?:\p{L}|\d|_)+))</string>
-				</dict>
-				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.other.powershell</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>storage.modifier.scope.powershell</string>
-						</dict>
-						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>variable.other.readwrite.powershell</string>
-						</dict>
-						<key>4</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.other.powershell</string>
 						</dict>
 						<key>5</key>
 						<dict>
 							<key>name</key>
-							<string>entity.name.function.invocation.powershell</string>
+							<string>keyword.other.powershell</string>
 						</dict>
 					</dict>
+					<key>comment</key>
+					<string>${var}, ${script:var}</string>
 					<key>match</key>
-					<string>(?i:(\$\{)(global|local|private|script|using|workflow):([^}]*[^}`])(\}))</string>
+					<string>(\$)(\{)((?i:global|local|script|private|using|env|function|alias|cert|variable|hkcu|hklm|wsman):)?(.+)(\})</string>
 				</dict>
 				<dict>
 					<key>captures</key>
@@ -1176,53 +1244,13 @@
 						<key>2</key>
 						<dict>
 							<key>name</key>
-							<string>support.variable.drive.powershell</string>
-						</dict>
-						<key>3</key>
-						<dict>
-							<key>name</key>
 							<string>variable.other.readwrite.powershell</string>
 						</dict>
-						<key>4</key>
-						<dict>
-							<key>name</key>
-							<string>entity.name.function.invocation.powershell</string>
-						</dict>
 					</dict>
+					<key>comment</key>
+					<string>Splatting</string>
 					<key>match</key>
-					<string>(?i:(\$)((?:\p{L}|\d|_)+:)?((?:\p{L}|\d|_)+))</string>
-				</dict>
-				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.other.powershell</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>support.variable.drive.powershell</string>
-						</dict>
-						<key>3</key>
-						<dict>
-							<key>name</key>
-							<string>variable.other.readwrite.powershell</string>
-						</dict>
-						<key>4</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.other.powershell</string>
-						</dict>
-						<key>5</key>
-						<dict>
-							<key>name</key>
-							<string>entity.name.function.invocation.powershell</string>
-						</dict>
-					</dict>
-					<key>match</key>
-					<string>(?i:(\$\{)((?:\p{L}|\d|_)+:)?([^}]*[^}`])(\}))</string>
+					<string>(@)(\w+)</string>
 				</dict>
 			</array>
 		</dict>

--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -45,7 +45,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(?&lt;![\\-])#</string>
+			<string>(?&lt;![\\-])(?:\s+?|^)#</string>
 			<key>end</key>
 			<string>$</string>
 			<key>name</key>

--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -89,6 +89,10 @@
 			<string>#type</string>
 		</dict>
 		<dict>
+			<key>include</key>
+			<string>#parameter</string>
+		</dict>
+		<dict>
 			<key>begin</key>
 			<string>(?&lt;!(?&lt;!`)")"</string>
 			<key>end</key>
@@ -692,6 +696,13 @@
 					<string>constant.numeric.scientific.powershell</string>
 				</dict>
 			</array>
+		</dict>
+		<key>parameter</key>
+		<dict>
+			<key>match</key>
+			<string>((?&lt;=\s)-(\w+))</string>
+			<key>name</key>
+			<string>variable.parameter.powershell</string>
 		</dict>
 		<key>scriptblock</key>
 		<dict>

--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -250,7 +250,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>(?&lt;!\w)((?i:begin|break|catch|continue|data|define|do|dynamicparam|else|elseif|end|exit|finally|for|foreach(?!-object)|from|if|in|inlinescript|parallel|param|process|return|switch|throw|trap|try|until|using|var|where(?!=-object)|while)|%|\?)(?!\w)</string>
+			<string>(?&lt;!\w)((?i:begin|break|catch|continue|data|define|do|dynamicparam|node|else|elseif|end|exit|finally|for|foreach(?!-object)|from|if|in|inlinescript|parallel|param|process|return|switch|throw|trap|try|until|using|var|where(?!=-object)|while)|%|\?)(?!\w)</string>
 			<key>name</key>
 			<string>keyword.control.powershell</string>
 		</dict>
@@ -526,7 +526,7 @@
 		<key>function</key>
 		<dict>
 			<key>begin</key>
-			<string>(?&lt;!\S)(?i)(function|filter|configuration|workflow)\s+(?:(global|local|script|private):)?((?:\p{L}|\d|_|-|\.)+)</string>
+			<string>(?&lt;!\S)(?i)(function|filter|workflow|configuration)\s+(?:(global|local|script|private):)?((?:\p{L}|\d|_|-|\.)+)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>0</key>

--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -246,7 +246,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>(?&lt;!\w)((?i:begin|break|catch|continue|data|define|do|dynamicparam|else|elseif|end|enum|exit|finally|for|foreach(?!-object)|from|if|in|inlinescript|parallel|param|process|return|switch|throw|trap|try|until|using|var|where(?!=-object)|while)|%|\?)(?!\w)</string>
+			<string>(?&lt;!\w)((?i:begin|break|catch|continue|data|define|do|dynamicparam|else|elseif|end|exit|finally|for|foreach(?!-object)|from|if|in|inlinescript|parallel|param|process|return|switch|throw|trap|try|until|using|var|where(?!=-object)|while)|%|\?)(?!\w)</string>
 			<key>name</key>
 			<string>keyword.control.powershell</string>
 		</dict>
@@ -267,7 +267,7 @@
 			<key>comment</key>
 			<string>capture should be entity.name.type, but it doesn't provide a good color in the default schema.</string>
 			<key>match</key>
-			<string>(?&lt;!\w|-)((?i:class)|%|\?)(?:\s)+((?:\p{L}|\d|_|-|)+)\b</string>
+			<string>(?&lt;!\w|-)((?i:class|enum)|%|\?)(?:\s)+((?:\p{L}|\d|_|-|)+)\b</string>
 		</dict>
 		<dict>
 			<key>match</key>

--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -254,7 +254,7 @@
 			<array>
 				<dict>
 					<key>begin</key>
-					<string>\b((?i:(Invoke))-(\w+))\b</string>
+					<string>(?&lt;!\\)\b((?i:(Add|Approve|Assert|Backup|Block|Checkpoint|Clear|Close|Compare|Complete|Compress|Confirm|Connect|Convert|ConvertFrom|ConvertTo|Copy|Debug|Deny|Disable|Disconnect|Dismount|Edit|Enable|Enter|Exit|Expand|Export|Find|Format|Get|Grant|Group|Hide|Import|Initialize|Install|Invoke|Join|Limit|Lock|Measure|Merge|Mount|Move|New|Open|Optimize|Out|Ping|Pop|Protect|Publish|Push|Read|Receive|Redo|Register|Remove|Rename|Repair|Request|Reset|Resize|Resolve|Restart|Restore|Resume|Revoke|Save|Search|Select|Send|Set|Show|Skip|Split|Start|Step|Stop|Submit|Suspend|Switch|Sync|Test|Trace|Unblock|Undo|Uninstall|Unlock|Unprotect|Unpublish|Unregister|Update|Use|Wait|Watch|Write))-(\w+))\b</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>

--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -148,7 +148,7 @@
 		<dict>
 			<key>begin</key>
 			<string>(\@?\()</string>
-			<key>captures</key>
+			<key>beginCaptures</key>
 			<dict>
 				<key>0</key>
 				<dict>
@@ -157,7 +157,20 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>(\))</string>
+			<string>(\))((\.[\w"']+)*)</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.other.powershell</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>entity.other.attribute-name.powershell</string>
+				</dict>
+			</dict>
 			<key>name</key>
 			<string>meta.array.powershell</string>
 			<key>patterns</key>
@@ -254,7 +267,7 @@
 			<array>
 				<dict>
 					<key>begin</key>
-					<string>(?&lt;!\\)\b((?i:(Add|Approve|Assert|Backup|Block|Checkpoint|Clear|Close|Compare|Complete|Compress|Confirm|Connect|Convert|ConvertFrom|ConvertTo|Copy|Debug|Deny|Disable|Disconnect|Dismount|Edit|Enable|Enter|Exit|Expand|Export|Find|Format|Get|Grant|Group|Hide|Import|Initialize|Install|Invoke|Join|Limit|Lock|Measure|Merge|Mount|Move|New|Open|Optimize|Out|Ping|Pop|Protect|Publish|Push|Read|Receive|Redo|Register|Remove|Rename|Repair|Request|Reset|Resize|Resolve|Restart|Restore|Resume|Revoke|Save|Search|Select|Send|Set|Show|Skip|Split|Start|Step|Stop|Submit|Suspend|Switch|Sync|Test|Trace|Unblock|Undo|Uninstall|Unlock|Unprotect|Unpublish|Unregister|Update|Use|Wait|Watch|Write))-(\w+))\b</string>
+					<string>(?&lt;!\\)\b((?i:(Add|Approve|Assert|Backup|Block|Checkpoint|Clear|Close|Compare|Complete|Compress|Confirm|Connect|Convert|ConvertFrom|ConvertTo|Copy|Debug|Deny|Disable|Disconnect|Dismount|Edit|Enable|Enter|Exit|Expand|Export|Find|Format|Get|Grant|Group|Hide|Import|Initialize|Install|Invoke|Join|Limit|Lock|Measure|Merge|Mount|Move|New|Open|Optimize|Out|Ping|Pop|Protect|Publish|Push|Read|Receive|Redo|Register|Remove|Rename|Repair|Request|Reset|Resize|Resolve|Restart|Restore|Resume|Revoke|Save|Search|Select|Send|Set|Show|Skip|Split|Start|Step|Stop|Submit|Suspend|Switch|Sync|Test|Trace|Unblock|Undo|Uninstall|Unlock|Unprotect|Unpublish|Unregister|Update|Use|Wait|Watch|Write))-(\w+))\b(?!\.|\\)</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>
@@ -264,9 +277,9 @@
 						</dict>
 					</dict>
 					<key>comment</key>
-					<string>Verb-Noun</string>
+					<string>Generic function match based on Verb-Noun pair using list of approved verbs.</string>
 					<key>end</key>
-					<string>((?=\))|(?&lt;!`)\n|(?&lt;!`)\r|(\|))</string>
+					<string>((?=\))|(?=\})|(?&lt;!`)\n|(?&lt;!`)\r|(\|))</string>
 					<key>endCaptures</key>
 					<dict>
 						<key>2</key>
@@ -279,6 +292,241 @@
 					<string>meta.command.powershell</string>
 					<key>patterns</key>
 					<array>
+						<dict>
+							<key>include</key>
+							<string>#scriptblock</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#commandParameter</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#lineComment</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#redirection</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#numericConstant</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#operators</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#variable</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#stringDoubleQuoted</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#stringSingleQuoted</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#arrayDeclaration</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#illegalBacktick</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#illegalVariable</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>(?&lt;!\\)\b(?i:foreach-object|tee-object|where-object|sort-object)\b(?!\.|\\)</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>support.function.powershell</string>
+						</dict>
+					</dict>
+					<key>comment</key>
+					<string>Built-in commands that don't adhere to the approved verbs standard.</string>
+					<key>end</key>
+					<string>((?=\))|(?=\})|(?&lt;!`)\n|(?&lt;!`)\r|(\|))</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.operator.powershell</string>
+						</dict>
+					</dict>
+					<key>name</key>
+					<string>meta.command.powershell</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>#scriptblock</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#commandParameter</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#lineComment</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#redirection</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#numericConstant</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#operators</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#variable</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#stringDoubleQuoted</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#stringSingleQuoted</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#arrayDeclaration</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#illegalBacktick</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#illegalVariable</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>(?&lt;!\\|\[)\b(?i:ac|asnp|cat|cd|cfs|chdir|clc|clear|clhy|cli|clp|cls|clv|cnsn|compare|copy|cp|cpi|cpp|curl|cvpa|dbp|del|diff|dir|dnsn|ebp|echo|epal|epcsv|epsn|erase|etsn|exsn|fc|fhx|fl|ft|fw|gal|gbp|gc|gcb|gci|gcm|gcs|gdr|ghy|gi|gjb|gl|gm|gmo|gp|gps|gpv|group|gsn|gsnp|gsv|gu|gv|gwmi|h|history|icm|iex|ihy|ii|ipal|ipcsv|ipmo|ipsn|irm|ise|iwmi|iwr|kill|lp|ls|man|md|measure|mi|mount|move|mp|mv|nal|ndr|ni|nmo|npssc|nsn|nv|ogv|oh|popd|ps|pushd|r|rbp|rcjb|rcsn|rd|rdr|ren|ri|rjb|rm|rmdir|rmo|rni|rnp|rp|rsn|rsnp|rujb|rv|rvpa|rwmi|sajb|sal|saps|sasv|sbp|sc|scb|select|set|shcm|si|sl|sleep|sls|sort|sp|spjb|spps|spsv|start|sujb|sv|swmi|tee|trcm|type|wget|wjb|write)\b(?!\.|\\|\])</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>support.function.powershell</string>
+						</dict>
+					</dict>
+					<key>comment</key>
+					<string>Built-in aliases</string>
+					<key>end</key>
+					<string>((?=\))|(?=\})|(?&lt;!`)\n|(?&lt;!`)\r|(\|))</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.operator.powershell</string>
+						</dict>
+					</dict>
+					<key>name</key>
+					<string>meta.command.powershell</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>#scriptblock</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#commandParameter</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#lineComment</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#redirection</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#numericConstant</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#operators</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#variable</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#stringDoubleQuoted</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#stringSingleQuoted</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#arrayDeclaration</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#illegalBacktick</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#illegalVariable</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>(\b(([A-Za-z0-9\-_\.]+).(?i:ps1))\b)</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>support.function.powershell</string>
+						</dict>
+					</dict>
+					<key>comment</key>
+					<string>Calling external script</string>
+					<key>end</key>
+					<string>((?=\))|(?=\})|(?&lt;!`)\n|(?&lt;!`)\r|(\|))</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.operator.powershell</string>
+						</dict>
+					</dict>
+					<key>name</key>
+					<string>meta.command.powershell</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>#scriptblock</string>
+						</dict>
 						<dict>
 							<key>include</key>
 							<string>#commandParameter</string>
@@ -641,9 +889,9 @@
 		<key>executableFiles</key>
 		<dict>
 			<key>comment</key>
-			<string>Executable files, like exe, com, ps1, cmd and bat</string>
+			<string>Executable files, like exe, com, cmd and bat</string>
 			<key>match</key>
-			<string>(\b(([A-Za-z0-9\-_\.]+).(?i:exe|com|ps1|cmd|bat))\b)</string>
+			<string>(\b(([A-Za-z0-9\-_\.]+).(?i:exe|com|cmd|bat))\b)</string>
 			<key>name</key>
 			<string>support.function.powershell</string>
 		</dict>
@@ -1104,13 +1352,23 @@
 			<key>comment</key>
 			<string>Type []</string>
 			<key>end</key>
-			<string>\]</string>
+			<string>(\])(::[\w]+)*((\.[\w"']+)*)</string>
 			<key>endCaptures</key>
 			<dict>
-				<key>0</key>
+				<key>1</key>
 				<dict>
 					<key>name</key>
 					<string>keyword.other.powershell</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>meta.method.powershell</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>entity.other.attribute-name.powershell</string>
 				</dict>
 			</dict>
 			<key>patterns</key>
@@ -1209,11 +1467,16 @@
 							<key>name</key>
 							<string>variable.other.readwrite.powershell</string>
 						</dict>
+						<key>5</key>
+						<dict>
+							<key>name</key>
+							<string>entity.other.attribute-name.powershell</string>
+						</dict>
 					</dict>
 					<key>comment</key>
 					<string>$var, $local:var</string>
 					<key>match</key>
-					<string>(\$)((?i:global|local|script|private|using|env|function|alias|cert|variable|hkcu|hklm|wsman):)?(\w+)(:\w+)?</string>
+					<string>(\$)((?i:global|local|script|private|using|env|function|alias|cert|variable|hkcu|hklm|wsman):)?(\w+)(:\w+)?((\.[\w"']+)*)</string>
 				</dict>
 				<dict>
 					<key>captures</key>
@@ -1243,11 +1506,16 @@
 							<key>name</key>
 							<string>keyword.other.powershell</string>
 						</dict>
+						<key>6</key>
+						<dict>
+							<key>name</key>
+							<string>entity.other.attribute-name.powershell</string>
+						</dict>
 					</dict>
 					<key>comment</key>
 					<string>${var}, ${script:var}</string>
 					<key>match</key>
-					<string>(\$)(\{)((?i:global|local|script|private|using|env|function|alias|cert|variable|hkcu|hklm|wsman):)?(.+)(\})</string>
+					<string>(\$)(\{)((?i:global|local|script|private|using|env|function|alias|cert|variable|hkcu|hklm|wsman):)?(.+)(\})((\.[\w"']+)*)</string>
 				</dict>
 				<dict>
 					<key>captures</key>

--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -267,7 +267,7 @@
 			<key>comment</key>
 			<string>capture should be entity.name.type, but it doesn't provide a good color in the default schema.</string>
 			<key>match</key>
-			<string>(?&lt;!\w)((?i:class)|%|\?)(?:\s)+((?:\p{L}|\d|_|-|)+)\b</string>
+			<string>(?&lt;!\w|-)((?i:class)|%|\?)(?:\s)+((?:\p{L}|\d|_|-|)+)\b</string>
 		</dict>
 		<dict>
 			<key>match</key>

--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -103,10 +103,6 @@
 			<string>#type</string>
 		</dict>
 		<dict>
-			<key>include</key>
-			<string>#parameter</string>
-		</dict>
-		<dict>
 			<key>begin</key>
 			<string>(?&lt;!(?&lt;!`)")"</string>
 			<key>end</key>
@@ -313,7 +309,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>(?&lt;!\w)-(?i:band|bor|bnot|bxor)(?!\p{L})</string>
+			<string>(?&lt;!\w)-(?i:band|bor|bnot|bxor|shr|shl)(?!\p{L})</string>
 			<key>name</key>
 			<string>keyword.operator.bitwise.powershell</string>
 		</dict>
@@ -322,6 +318,10 @@
 			<string>(?&lt;!\w)-(?i:f)(?!\p{L})</string>
 			<key>name</key>
 			<string>keyword.operator.string-format.powershell</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#parameter</string>
 		</dict>
 		<dict>
 			<key>match</key>

--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -470,7 +470,7 @@
 						</dict>
 					</dict>
 					<key>comment</key>
-					<string>Calling external script</string>
+					<string>External script</string>
 					<key>end</key>
 					<string>((?=\))|(?=\})|(?&lt;!`)\n|(?&lt;!`)\r|(\|))</string>
 					<key>endCaptures</key>

--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -271,7 +271,7 @@
 			<key>comment</key>
 			<string>capture should be entity.name.type, but it doesn't provide a good color in the default schema.</string>
 			<key>match</key>
-			<string>(?&lt;!\w|-)((?i:class|enum)|%|\?)(?:\s)+((?:\p{L}|\d|_|-|)+)\b</string>
+			<string>(?&lt;!\w|-)((?i:class|enum)|%|\?)(?:\s)+((?:\p{L}|\d|_|)+)\b</string>
 		</dict>
 		<dict>
 			<key>match</key>

--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -404,7 +404,7 @@
 						</dict>
 						<dict>
 							<key>include</key>
-							<string>#variable</string>
+							<string>$self</string>
 						</dict>
 					</array>
 				</dict>

--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -566,6 +566,13 @@
 			</dict>
 			<key>end</key>
 			<string>\{|\(</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#lineComment</string>
+				</dict>
+			</array>
 		</dict>
 		<key>interpolatedStringContent</key>
 		<dict>

--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -45,18 +45,32 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(?&lt;![\\-])(?:\s+?|^)#</string>
+			<string>--%</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.control.powershell</string>
+				</dict>
+			</dict>
+			<key>comment</key>
+			<string>Stop Parsing</string>
+			<key>contentName</key>
+			<string>source.powershell</string>
 			<key>end</key>
 			<string>$</string>
-			<key>name</key>
-			<string>comment.line.number-sign.powershell</string>
 			<key>patterns</key>
 			<array>
 				<dict>
 					<key>include</key>
-					<string>#commentEmbeddedDocs</string>
+					<string>#lineComment</string>
 				</dict>
 			</array>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#lineComment</string>
 		</dict>
 		<dict>
 			<key>match</key>
@@ -630,6 +644,22 @@
 				<dict>
 					<key>include</key>
 					<string>#interpolatedStringContent</string>
+				</dict>
+			</array>
+		</dict>
+		<key>lineComment</key>
+		<dict>
+			<key>begin</key>
+			<string>(?&lt;![\\-])(?:\s+?|^)#</string>
+			<key>end</key>
+			<string>$</string>
+			<key>name</key>
+			<string>comment.line.number-sign.powershell</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#commentEmbeddedDocs</string>
 				</dict>
 			</array>
 		</dict>

--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -1108,11 +1108,11 @@
 			<array>
 				<dict>
 					<key>include</key>
-					<string>#stringEscapeChars</string>
+					<string>#illegalVariable</string>
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#illegalVariable</string>
+					<string>#stringEscapeChars</string>
 				</dict>
 				<dict>
 					<key>include</key>
@@ -1134,6 +1134,10 @@
 			<string>string.quoted.double.heredoc.powershell</string>
 			<key>patterns</key>
 			<array>
+				<dict>
+					<key>include</key>
+					<string>#illegalVariable</string>
+				</dict>
 				<dict>
 					<key>include</key>
 					<string>#stringEscapeChars</string>

--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -74,6 +74,12 @@
 		</dict>
 		<dict>
 			<key>match</key>
+			<string>(`(?!$))</string>
+			<key>name</key>
+			<string>invalid.illegal.powershell</string>
+		</dict>
+		<dict>
+			<key>match</key>
 			<string>[2-6]&gt;&amp;1|&gt;&gt;|&gt;|&lt;&lt;|&lt;|&gt;|&gt;\||[1-6]&gt;|[1-6]&gt;&gt;</string>
 			<key>name</key>
 			<string>keyword.operator.redirection.powershell</string>

--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -107,6 +107,10 @@
 		</dict>
 		<dict>
 			<key>include</key>
+			<string>#enum</string>
+		</dict>
+		<dict>
+			<key>include</key>
 			<string>#class</string>
 		</dict>
 		<dict>
@@ -191,7 +195,9 @@
 		</dict>
 		<key>class</key>
 		<dict>
-			<key>captures</key>
+			<key>begin</key>
+			<string>(?&lt;!\w|-)(?i:(class))\s+(\w+)(?:\s*(:)\s*(\w+))?\s*\{</string>
+			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
 				<dict>
@@ -201,13 +207,69 @@
 				<key>2</key>
 				<dict>
 					<key>name</key>
-					<string>entity.name.function</string>
+					<string>entity.name.function.powershell</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.operator.powershell</string>
+				</dict>
+				<key>4</key>
+				<dict>
+					<key>name</key>
+					<string>entity.other.inherited-class.powershell</string>
 				</dict>
 			</dict>
 			<key>comment</key>
-			<string>capture should be entity.name.type, but it doesn't provide a good color in the default schema.</string>
+			<string>Class</string>
+			<key>end</key>
+			<string>\}</string>
+			<key>name</key>
+			<string>meta.class.powershell</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#classReservedWords</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#classBaseKeyword</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>$self</string>
+				</dict>
+			</array>
+		</dict>
+		<key>classBaseKeyword</key>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.operator.powershell</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.control.class.powershell</string>
+				</dict>
+			</dict>
+			<key>comment</key>
+			<string>The base keyword used in classes.</string>
 			<key>match</key>
-			<string>(?&lt;!\w|-)(?i:(class|enum))\s+(\w+)\s+</string>
+			<string>(:)\s*(?i:(base))\s*(?=\()</string>
+		</dict>
+		<key>classReservedWords</key>
+		<dict>
+			<key>comment</key>
+			<string>Reserved words for classes.</string>
+			<key>match</key>
+			<string>\b(?i:(hidden|static))\b</string>
+			<key>name</key>
+			<string>keyword.other.powershell</string>
 		</dict>
 		<key>commandParameter</key>
 		<dict>
@@ -713,6 +775,26 @@
 			<key>match</key>
 			<string>(?i:(default))\s*(?=\{)</string>
 		</dict>
+		<key>enum</key>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>storage.type.powershell</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.function</string>
+				</dict>
+			</dict>
+			<key>comment</key>
+			<string>capture should be entity.name.type, but it doesn't provide a good color in the default schema.</string>
+			<key>match</key>
+			<string>(?&lt;!\w|-)(?i:(enum))\s+(\w+)\s+</string>
+		</dict>
 		<key>executableFiles</key>
 		<dict>
 			<key>comment</key>
@@ -990,7 +1072,7 @@
 		<key>reservedWords</key>
 		<dict>
 			<key>match</key>
-			<string>(\b(?&lt;!-|\$)(?i:configuration|node|process|enum|filter|sequence|class|switch|data|define|function|dynamicparam|inlinescript|var|parallel|param|workflow)\b(?!-|\.))</string>
+			<string>(\b(?&lt;!-|\$)(?i:configuration|node|process|enum|filter|sequence|class|data|define|function|dynamicparam|inlinescript|var|parallel|param|workflow)\b(?!-|\.))</string>
 			<key>name</key>
 			<string>keyword.other.powershell</string>
 		</dict>

--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -1116,7 +1116,7 @@
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#variable</string>
+					<string>#variableWithoutPropertyHighlighting</string>
 				</dict>
 				<dict>
 					<key>include</key>
@@ -1140,7 +1140,7 @@
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#variable</string>
+					<string>#variableWithoutPropertyHighlighting</string>
 				</dict>
 				<dict>
 					<key>include</key>
@@ -1493,6 +1493,121 @@
 					<string>${var}, ${script:var}</string>
 					<key>match</key>
 					<string>(\$)(\{)((?i:global|local|script|private|using|env|function|alias|cert|variable|hkcu|hklm|wsman):)?(.+)(\})((\.[\w"']+)*)</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.other.powershell</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>variable.other.readwrite.powershell</string>
+						</dict>
+					</dict>
+					<key>comment</key>
+					<string>Splatting</string>
+					<key>match</key>
+					<string>(@)(\w+)</string>
+				</dict>
+			</array>
+		</dict>
+		<key>variableWithoutPropertyHighlighting</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>comment</key>
+					<string>Invalid variable name</string>
+					<key>match</key>
+					<string>(\$)(\w+-\w+)\b</string>
+					<key>name</key>
+					<string>invalid.illegal.powershell</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>constant.language.powershell</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>constant.language.powershell</string>
+						</dict>
+					</dict>
+					<key>comment</key>
+					<string>Automatic variables - read-only.</string>
+					<key>match</key>
+					<string>(\$)(?i:(_|args|consolefilename|error|event|eventsubscriber|executioncontext|false|foreach|home|host|input|lastexitcode|matches|myinvocation|nestedpromptlevel|null|pid|psboundparameters|pscmdlet|psculture|psdebugcontext|pshome|psitem|psscriptroot|psuiculture|psversiontable|pwd|sender|shellid|sourceargs|sourceeventargs|switch|this|true))\b</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.other.powershell</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>storage.modifier.scope.powershell</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>variable.other.readwrite.powershell</string>
+						</dict>
+						<key>4</key>
+						<dict>
+							<key>name</key>
+							<string>variable.other.readwrite.powershell</string>
+						</dict>
+					</dict>
+					<key>comment</key>
+					<string>$var, $local:var</string>
+					<key>match</key>
+					<string>(\$)((?i:global|local|script|private|using|env|function|alias|cert|variable|hkcu|hklm|wsman):)?(\w+)(:\w+)?</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.other.powershell</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.other.powershell</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>storage.modifier.scope.powershell</string>
+						</dict>
+						<key>4</key>
+						<dict>
+							<key>name</key>
+							<string>variable.other.readwrite.powershell</string>
+						</dict>
+						<key>5</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.other.powershell</string>
+						</dict>
+					</dict>
+					<key>comment</key>
+					<string>${var}, ${script:var}</string>
+					<key>match</key>
+					<string>(\$)(\{)((?i:global|local|script|private|using|env|function|alias|cert|variable|hkcu|hklm|wsman):)?(.+)(\})</string>
 				</dict>
 				<dict>
 					<key>captures</key>

--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -471,7 +471,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(?i:(\.)(SYNOPSIS|DESCRIPTION|EXAMPLE|INPUTS|OUTPUTS|NOTES|LINK|COMPONENT|FUNCTIONALITY)\b)</string>
+					<string>(?i:(\.)(SYNOPSIS|DESCRIPTION|EXAMPLE|INPUTS|OUTPUTS|NOTES|LINK|COMPONENT|FUNCTIONALITY|ROLE)\b)</string>
 					<key>name</key>
 					<string>comment.documentation.embedded.powershell</string>
 				</dict>

--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -71,6 +71,10 @@
 		</dict>
 		<dict>
 			<key>include</key>
+			<string>#switch</string>
+		</dict>
+		<dict>
+			<key>include</key>
 			<string>#scriptBlock</string>
 		</dict>
 		<dict>
@@ -115,19 +119,11 @@
 		</dict>
 		<dict>
 			<key>include</key>
-			<string>#commands-OLD</string>
-		</dict>
-		<dict>
-			<key>include</key>
-			<string>#commands-NEW</string>
+			<string>#commands</string>
 		</dict>
 		<dict>
 			<key>include</key>
 			<string>#executableFiles</string>
-		</dict>
-		<dict>
-			<key>include</key>
-			<string>#parameter-OLD</string>
 		</dict>
 		<dict>
 			<key>include</key>
@@ -136,10 +132,6 @@
 		<dict>
 			<key>include</key>
 			<string>#variable</string>
-		</dict>
-		<dict>
-			<key>include</key>
-			<string>#demoScopeHighlighting</string>
 		</dict>
 	</array>
 	<key>repository</key>
@@ -225,43 +217,13 @@
 					<key>comment</key>
 					<string>-Parameter value</string>
 					<key>match</key>
-					<string>(-\w+)(:)?</string>
+					<string>\s(-\w+)(:)?</string>
 					<key>name</key>
 					<string>variable.parameter.powershell</string>
 				</dict>
 			</array>
 		</dict>
 		<key>commands</key>
-		<dict>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>comment</key>
-					<string>Generic function match based on Verb-Noun pair using list of approved verbs.</string>
-					<key>match</key>
-					<string>(?&lt;!\\)\b(?i:Add|Approve|Assert|Backup|Block|Checkpoint|Clear|Close|Compare|Complete|Compress|Confirm|Connect|Convert|ConvertFrom|ConvertTo|Copy|Debug|Deny|Disable|Disconnect|Dismount|Edit|Enable|Enter|Exit|Expand|Export|Find|Format|Get|Grant|Group|Hide|Import|Initialize|Install|Invoke|Join|Limit|Lock|Measure|Merge|Mount|Move|New|Open|Optimize|Out|Ping|Pop|Protect|Publish|Push|Read|Receive|Redo|Register|Remove|Rename|Repair|Request|Reset|Resize|Resolve|Restart|Restore|Resume|Revoke|Save|Search|Select|Send|Set|Show|Skip|Split|Start|Step|Stop|Submit|Suspend|Switch|Sync|Test|Trace|Unblock|Undo|Uninstall|Unlock|Unprotect|Unpublish|Unregister|Update|Use|Wait|Watch|Write)-(?i:\w+)\b(?!\.|\\)</string>
-					<key>name</key>
-					<string>support.function.powershell</string>
-				</dict>
-				<dict>
-					<key>comment</key>
-					<string>Built-in commands that don't adhere to the approved verbs standard.</string>
-					<key>match</key>
-					<string>(?&lt;!\\)\b(?i:foreach-object|tee-object|where-object|sort-object)\b(?!\.|\\)</string>
-					<key>name</key>
-					<string>support.function.powershell</string>
-				</dict>
-				<dict>
-					<key>comment</key>
-					<string>Built-in aliases</string>
-					<key>match</key>
-					<string>(?&lt;!\\|\[)\b(?i:ac|asnp|cat|cd|cfs|chdir|clc|clear|clhy|cli|clp|cls|clv|cnsn|compare|copy|cp|cpi|cpp|curl|cvpa|dbp|del|diff|dir|dnsn|ebp|echo|epal|epcsv|epsn|erase|etsn|exsn|fc|fhx|fl|ft|fw|gal|gbp|gc|gcb|gci|gcm|gcs|gdr|ghy|gi|gjb|gl|gm|gmo|gp|gps|gpv|group|gsn|gsnp|gsv|gu|gv|gwmi|h|history|icm|iex|ihy|ii|ipal|ipcsv|ipmo|ipsn|irm|ise|iwmi|iwr|kill|lp|ls|man|md|measure|mi|mount|move|mp|mv|nal|ndr|ni|nmo|npssc|nsn|nv|ogv|oh|popd|ps|pushd|r|rbp|rcjb|rcsn|rd|rdr|ren|ri|rjb|rm|rmdir|rmo|rni|rnp|rp|rsn|rsnp|rujb|rv|rvpa|rwmi|sajb|sal|saps|sasv|sbp|sc|scb|select|set|shcm|si|sl|sleep|sls|sort|sp|spjb|spps|spsv|start|sujb|sv|swmi|tee|trcm|type|wget|wjb|write)\b(?!\.|\\|\])</string>
-					<key>name</key>
-					<string>support.other.alias.powershell</string>
-				</dict>
-			</array>
-		</dict>
-		<key>commands-NEW</key>
 		<dict>
 			<key>patterns</key>
 			<array>
@@ -736,155 +698,20 @@
 			<key>name</key>
 			<string>keyword.control.powershell</string>
 		</dict>
-		<key>demoScopeHighlighting</key>
+		<key>defaultKeyword</key>
 		<dict>
-			<key>patterns</key>
-			<array>
+			<key>captures</key>
+			<dict>
+				<key>0</key>
 				<dict>
-					<key>match</key>
-					<string>\b(demo_scope_constantLanguage)\b</string>
 					<key>name</key>
-					<string>constant.language</string>
+					<string>keyword.other.powershell</string>
 				</dict>
-				<dict>
-					<key>match</key>
-					<string>\b(demo_scope_constantNumeric)\b</string>
-					<key>name</key>
-					<string>constant.numeric</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>\b(demo_scope_constantOther)\b</string>
-					<key>name</key>
-					<string>constant.other</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>\b(demo_scope_constantCharacterEscape)\b</string>
-					<key>name</key>
-					<string>constant.character.escape</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>\b(demo_scope_entityOtherAttributeName)\b</string>
-					<key>name</key>
-					<string>entity.other.attribute-name</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>\b(demo_scope_invalid)\b</string>
-					<key>name</key>
-					<string>invalid</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>\b(demo_scope_comment)\b</string>
-					<key>name</key>
-					<string>comment</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>\b(demo_scope_metaSelector)\b</string>
-					<key>name</key>
-					<string>meta.selector</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>\b(demo_scope_storageType)\b</string>
-					<key>name</key>
-					<string>storage.type</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>\b(demo_scope_string)\b</string>
-					<key>name</key>
-					<string>string</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>\b(demo_scope_keywordControl)\b</string>
-					<key>name</key>
-					<string>keyword.control</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>\b(demo_scope_keywordOperator)\b</string>
-					<key>name</key>
-					<string>keyword.operator</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>\b(demo_scope_keywordOtherUnit)\b</string>
-					<key>name</key>
-					<string>keyword.other.unit</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>\b(demo_scope_supportType)\b</string>
-					<key>name</key>
-					<string>support.type</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>\b(demo_scope_supportConstant)\b</string>
-					<key>name</key>
-					<string>support.constant</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>\b(demo_scope_supportVariable)\b</string>
-					<key>name</key>
-					<string>support.variable</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>\b(demo_scope_entityNameClass)\b</string>
-					<key>name</key>
-					<string>entity.name.class</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>\b(demo_scope_entityNameType)\b</string>
-					<key>name</key>
-					<string>entity.name.type</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>\b(demo_scope_entityNameFunction)\b</string>
-					<key>name</key>
-					<string>entity.name.function</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>\b(demo_scope_metaParameterTypeVariable)\b</string>
-					<key>name</key>
-					<string>meta.parameter.type.variable</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>\b(demo_scope_metaTypeAnnotation)\b</string>
-					<key>name</key>
-					<string>meta.type.annotation</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>\b(demo_scope_variableParameter)\b</string>
-					<key>name</key>
-					<string>variable.parameter</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>\b(demo_scope_variableLanguage)\b</string>
-					<key>name</key>
-					<string>variable.language</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>\b(demo_scope_variableOther)\b</string>
-					<key>name</key>
-					<string>variable.other</string>
-				</dict>
-			</array>
+			</dict>
+			<key>comment</key>
+			<string>Default is a reserved word when used in Switch statements. This is kind of a work-around - it will highlight only inside scriptblocks.</string>
+			<key>match</key>
+			<string>(?i:(default))\s*(?=\{)</string>
 		</dict>
 		<key>executableFiles</key>
 		<dict>
@@ -1138,13 +965,6 @@
 				</dict>
 			</array>
 		</dict>
-		<key>parameter</key>
-		<dict>
-			<key>match</key>
-			<string>((?&lt;=\s)-(\w+))</string>
-			<key>name</key>
-			<string>variable.parameter.powershell</string>
-		</dict>
 		<key>redirection</key>
 		<dict>
 			<key>patterns</key>
@@ -1174,12 +994,12 @@
 			<key>name</key>
 			<string>keyword.other.powershell</string>
 		</dict>
-		<key>scriptblock</key>
+		<key>scriptBlock</key>
 		<dict>
 			<key>begin</key>
-			<string>\{</string>
+			<string>(\{)</string>
 			<key>end</key>
-			<string>\}</string>
+			<string>(\})</string>
 			<key>name</key>
 			<string>meta.scriptblock.powershell</string>
 			<key>patterns</key>
@@ -1187,6 +1007,10 @@
 				<dict>
 					<key>include</key>
 					<string>$self</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#defaultKeyword</string>
 				</dict>
 			</array>
 		</dict>
@@ -1215,10 +1039,6 @@
 				<dict>
 					<key>include</key>
 					<string>#subExpression</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#scriptBlock</string>
 				</dict>
 			</array>
 		</dict>
@@ -1334,6 +1154,65 @@
 					<string>(.)</string>
 					<key>name</key>
 					<string>source.powershell</string>
+				</dict>
+			</array>
+		</dict>
+		<key>switch</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.control.powershell</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>variable.parameter.powershell</string>
+						</dict>
+						<key>4</key>
+						<dict>
+							<key>name</key>
+							<string>variable.parameter.powershell</string>
+						</dict>
+						<key>5</key>
+						<dict>
+							<key>name</key>
+							<string>variable.parameter.powershell</string>
+						</dict>
+					</dict>
+					<key>comment</key>
+					<string>switch [-regex|-wildcard|-exact][-casesensitive] -file filename</string>
+					<key>match</key>
+					<string>\b(?i:(switch))\b\s+(?i:(-regex|-wildcard|-exact){0,1})\s*(?i:(-casesensitive){0,1})\s*(?i:(-file))\s+</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.control.powershell</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>variable.parameter.powershell</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>variable.parameter.powershell</string>
+						</dict>
+					</dict>
+					<key>comment</key>
+					<string>switch [-regex|-wildcard|-exact][-casesensitive] (&lt;value&gt;)</string>
+					<key>match</key>
+					<string>\b(?i:(switch))\b\s+(?i:(-regex|-wildcard|-exact){0,1})\s*(?i:(-casesensitive){0,1})\s*</string>
 				</dict>
 			</array>
 		</dict>

--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -266,7 +266,15 @@
 					<key>comment</key>
 					<string>Verb-Noun</string>
 					<key>end</key>
-					<string>((?=\))|(?&lt;!`)\n|(?&lt;!`)\r|\|)</string>
+					<string>((?=\))|(?&lt;!`)\n|(?&lt;!`)\r|(\|))</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.operator.powershell</string>
+						</dict>
+					</dict>
 					<key>name</key>
 					<string>meta.command.powershell</string>
 					<key>patterns</key>
@@ -281,7 +289,15 @@
 						</dict>
 						<dict>
 							<key>include</key>
+							<string>#redirection</string>
+						</dict>
+						<dict>
+							<key>include</key>
 							<string>#numericConstant</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#operators</string>
 						</dict>
 						<dict>
 							<key>include</key>
@@ -868,7 +884,7 @@
 					<key>comment</key>
 					<string>Command invocation (Call)</string>
 					<key>match</key>
-					<string>(&amp;)</string>
+					<string>(&amp;|\|)</string>
 					<key>name</key>
 					<string>keyword.operator.other.powershell</string>
 				</dict>

--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -248,7 +248,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>(?&lt;!\w)-([ci]?[lg][te]|eq|ne)</string>
+			<string>(?&lt;!\w)-([ci]?[lg][te]|eq|ne)\b</string>
 			<key>name</key>
 			<string>keyword.operator.logical.powershell</string>
 		</dict>

--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -456,7 +456,7 @@
 						<key>1</key>
 						<dict>
 							<key>name</key>
-							<string>constant.string.documentation.powershell</string>
+							<string>keyword.operator.documentation.powershell</string>
 						</dict>
 						<key>2</key>
 						<dict>
@@ -465,7 +465,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(?i:\s*(\.)(SYNOPSIS|DESCRIPTION|EXAMPLE|INPUTS|OUTPUTS|NOTES|LINK|COMPONENT|FUNCTIONALITY))</string>
+					<string>(?i:(\.)(SYNOPSIS|DESCRIPTION|EXAMPLE|INPUTS|OUTPUTS|NOTES|LINK|COMPONENT|FUNCTIONALITY)\b)</string>
 					<key>name</key>
 					<string>comment.documentation.embedded.powershell</string>
 				</dict>
@@ -475,7 +475,7 @@
 						<key>1</key>
 						<dict>
 							<key>name</key>
-							<string>constant.string.documentation.powershell</string>
+							<string>keyword.operator.documentation.powershell</string>
 						</dict>
 						<key>2</key>
 						<dict>
@@ -485,11 +485,11 @@
 						<key>3</key>
 						<dict>
 							<key>name</key>
-							<string>keyword.operator.documentation.powershell</string>
+							<string>constant.string.documentation.powershell</string>
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(?i:\s*(\.)(PARAMETER|FORWARDHELPTARGETNAME|FORWARDHELPCATEGORY|REMOTEHELPRUNSPACE|EXTERNALHELP)\s+([a-z0-9-_]+))</string>
+					<string>(?i:(\.)(PARAMETER|FORWARDHELPTARGETNAME|FORWARDHELPCATEGORY|REMOTEHELPRUNSPACE|EXTERNALHELP)\s+(.+))</string>
 					<key>name</key>
 					<string>comment.documentation.embedded.powershell</string>
 				</dict>
@@ -499,21 +499,16 @@
 						<key>1</key>
 						<dict>
 							<key>name</key>
-							<string>constant.string.documentation.powershell</string>
+							<string>keyword.operator.documentation.powershell</string>
 						</dict>
 						<key>2</key>
 						<dict>
 							<key>name</key>
-							<string>keyword.operator.documentation.powershell</string>
-						</dict>
-						<key>3</key>
-						<dict>
-							<key>name</key>
-							<string>string.quoted.double.heredoc.powershell</string>
+							<string>constant.string.documentation.powershell</string>
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(?i:requires\s+-(Version\s+\d(.\d+)?|Assembly\s+(.*)|Module\s+(.*)|PsSnapIn\s+(.*)|ShellId\s+(.*)))</string>
+					<string>((?i:requires))\s+-(Version\s+\d(?:.\d+)?|Assembly\s+(?:.*)|Module\s+(?:.*)|PsSnapIn\s+(?:.*)|ShellId\s+(?:.*))</string>
 					<key>name</key>
 					<string>comment.documentation.embedded.powershell</string>
 				</dict>

--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -1437,12 +1437,28 @@
 					<string>invalid.illegal.powershell</string>
 				</dict>
 				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>constant.language.powershell</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>constant.language.powershell</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>entity.other.attribute-name.powershell</string>
+						</dict>
+					</dict>
 					<key>comment</key>
 					<string>Automatic variables - read-only.</string>
 					<key>match</key>
-					<string>(\$)(?i:_|args|consolefilename|error|event|eventsubscriber|executioncontext|false|foreach|home|host|input|lastexitcode|matches|myinvocation|nestedpromptlevel|null|pid|psboundparameters|pscmdlet|psculture|psdebugcontext|pshome|psitem|psscriptroot|psuiculture|psversiontable|pwd|sender|shellid|sourceargs|sourceeventargs|switch|this|true)\b</string>
-					<key>name</key>
-					<string>constant.language.powershell</string>
+					<string>(\$)(?i:(_|args|consolefilename|error|event|eventsubscriber|executioncontext|false|foreach|home|host|input|lastexitcode|matches|myinvocation|nestedpromptlevel|null|pid|psboundparameters|pscmdlet|psculture|psdebugcontext|pshome|psitem|psscriptroot|psuiculture|psversiontable|pwd|sender|shellid|sourceargs|sourceeventargs|switch|this|true))\b((\.[\w"']+)*)</string>
 				</dict>
 				<dict>
 					<key>captures</key>

--- a/examples/TheBigTestFile.ps1
+++ b/examples/TheBigTestFile.ps1
@@ -1,0 +1,517 @@
+throw "Do not run this file!"
+
+<#
+
+	The big PowerShell syntax highlighting test file
+
+#>
+
+# Stop parsing
+& tool.exe /arg1 'value' /arg2 $value --% /arg3 $value /arg4 "value" # Comment
+
+# Automatic variables
+$_
+$args
+$error
+$home
+$foreach
+
+# Normal variables
+$variable
+$script:variable
+$ENV:ComputerName
+# This is not allowed
+$ENV:
+${variable}
+${script:variable}
+${#variableName}
+${'variableName'}
+${"$variableName"}
+${variable name}
+${script:this`{name`}is"valid"}
+
+# Variable properties should be highlighted
+$variable.Name
+($variable).Name
+
+# In double-quoted strings, only the variable should be highlighted, not the property
+"This is my $variable.Name!"
+
+# When used in a subexpression, both should be highlighted
+"This is my $($variable.Name)!"
+
+# $ENV:ComputerName should be highlighted
+"This is the name of my computer: $ENV:ComputerName"
+
+# Here as well
+"This is the name of my computer: ${ENV:ComputerName}"
+
+# This is still not allowed though
+"This is the name of my computer $ENV: "
+
+# This is an illegal variable name
+$variable-name
+
+# Hashtable
+$properties = @{
+	Name = 'Name'
+	Something = $else
+	Number = 16
+}
+
+# Spatting
+Invoke-Something @properties
+
+# ScriptBlock
+{Invoke-Something @properties}
+{
+	Invoke-Something @properties
+}
+$sb = {
+	Invoke-Something @properties
+}
+
+# Arrays
+$a1 = @(1,2,3,4)
+$a2 = ('one','two','three','four')
+$a3 = $one, $two, $three, $four
+$a1[0]
+$a2[-1]
+$a3[1..2]
+@(@($a))
+@(($i = 10); (++$j))
+@($i = 10)
+$i[($y - 1) + $x]
+
+# Single quoted strings
+'This is a single quoted string.'
+'$This is a single ''quoted'' string.'
+'This is a
+single quoted string.'
+'This #also'
+'$(Invoke-Something)'
+'This "string" is nice.'
+
+# Single quoted here-string
+@'
+$This is a ''single quoted''
+$('Here-String')
+Isn't it "nice"??
+'@
+
+# Double quoted strings
+"This is a double quoted string."
+"$This is a double ""quoted"" string."
+"This is a
+double quoted string."
+"This #also"
+"$(Invoke-Something)"
+"This 'string' is nice."
+
+# Double quoted here-string
+@"
+$This is a 'double quoted'
+$('Here-String')
+Isn't it "nice"??
+"@
+
+# Numeric constants
+-3
+.5
++.5
+1.
+1.d
+1.lGB
+1.e+12d
+1e+12d
+1.5
+-1.5
+-3 + -2
+-3+-2
+3++2
++2
+-3+-
+10/-10
+10/-10D
+-10.002L
+$x..5.40D
+-500..-495
+$true..3
+-2..$null
+-3..3
+1 .. 3kb
+1..3
+6,10,-3
+0x476
++0x20
+-0x20
+
+# Types
+[string]
+[string[]]
+[int32]
+[System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[System.Management.Automation.ParameterMetadata,System.Management.Automation]]]
+[System.Array+SZArrayEnumerator]
+[int]::MinValue
+[System.DateTime]::Parse('2016/09/21')
+
+# Commands (functions)
+Invoke-Something -foobar
+Invoke-Something -foobar value
+Invoke-Something -foobar:$true
+Invoke-Something -foobar: $true
+Invoke-Something -p1 v1 -p2 10 -p3 'value' -switch -verbose
+Invoke-Something (1..20 | Invoke-Something) -p2 'value'
+Invoke-Something -p1 v2 -p2 30 | Invoke-Something -switch
+Invoke-Something -p1 {
+	Invoke-Something -foobar:$true
+} | Invoke-Something
+Invoke-Something -p1 value `
+	-p2 14.4 `
+	-p3 $value | Invoke-Something -verbose
+
+# Commands (Built-in variables)
+ls *.ps1 -recurse
+
+# Commands (executable files)
+. .\scripts\myscript.ps1 -parameter 'value'
+& tool.exe
+something.cmd
+øyvind.com # this should also highlight - TODO!
+
+# But this should not highlight anything
+file.1
+This.txt
+Function.txt
+Where.txt
+ForEach-Object.txt
+
+# switch
+switch ("fourteen") {}
+switch -CaseSensitive ("fourteen") {}
+switch -Illegal ("fourteen") {} # Using illegal switch parameter
+switch -Regex ("fourteen") {}
+switch -Wildcard ($a) {}
+switch -regex -file .\somefile.txt {}
+switch (3) {}
+switch (4, 2) {} 
+
+switch -Regex -File $filePath {
+    '.' {}
+    default {}
+}
+
+switch -Wildcard -CaseSensitive ($something) {
+    '.' {}
+    default {}
+}
+
+switch ('this') {
+    'this' {}
+    default {}
+}
+
+# Illegal backtick
+Invoke-Command -arg1 $val1 `
+	           -arg2 $val2 ` 
+
+# Functions and filters
+functioN MyFunction{}
+function My-Function         {}
+Function My.Function{}
+function My-Function.Other{}
+function Some.other.function{}
+FUNCTION MyFunction2 {}
+function MyFunction3
+{
+
+}
+function New-File { }
+function New-File ($Name) { }
+function NewFile($Name) { }
+functionMyFunction{}
+filter myfilter($param) {}
+Filter my-Filter ($param){}
+
+function foo
+#comment 
+{
+    
+}
+
+# This one will not highlight the function name,
+# because of the comments after 'function'. TODO?
+function 
+<# another comment #>
+test
+(
+    [string]
+    <# another comment #>
+    [parameter(mandatory)]
+    $s
+)
+{
+    "test $s"
+}
+
+# Note that the # in the path should highlight as a comment!
+function Test-Drive([string]$roman) {
+	$roman | c:\users\Me\Documents\Programming\F#\test.exe $roman
+}
+
+function Get-EscapedPath
+{
+    param( 
+    [Parameter(
+        Position=0, 
+        Mandatory=$true
+        ValueFromPipeline=$true,
+        ValueFromPipelineByPropertyName=$true)
+    ]
+    [string]$path
+    ) 
+
+    process {
+        if ($path.Contains(' '))
+        {
+            return '"' + $path + '"'
+        }
+        return $path
+    }
+}
+
+# Enum
+enum test
+{
+    listItem1
+    listItem2
+    listItem3
+}
+
+# Illegal enum name
+enum my-Enum {
+
+}
+
+# Class
+class Vehicle {
+    Vehicle() {}
+    Vehicle([string]$Owner) {
+        $this.Owner = $Owner
+    }
+
+    [int]$Mileage
+    [int]$Age
+    [string]$Owner
+
+    [void]Drive([int]$NumberOfMiles) {
+        $this.Mileage += $NumberOfMiles
+    }
+}
+
+class Car: Vehicle {
+    Car() {}
+
+    Car([int]$Age) {
+        $this.Age = $Age
+    }
+
+    Car([int]$Age, [string]$Owner) : base([string]$Owner) {
+        $this.Age = $Age
+        $this.Owner = $Owner
+    }
+
+    hidden [int]$Length
+    static [int]$Width
+
+    SetLength([int]$Length) {
+        $this.Length = $Length
+    } 
+}
+
+# Illegal class name
+class my-class {}
+
+# Control words
+foreach ($item in $collection) {
+	try {
+		if ($item -gt 100) {
+			continue
+		}
+	}
+	catch {
+		break
+	}
+}
+
+# Reserved words
+Configuration Crazyness {
+    Node Whatever {
+    }
+}
+param ()
+
+# Redirection
+notepad.exe > log.txt
+notepad.exe 1> log.txt
+notepad.exe 2>&1
+notepad.exe 3>&1
+notepad.exe 4>&1
+notepad.exe 5>&1
+notepad.exe 6>&1
+notepad.exe 2>&1> log.txt
+
+# Note: 7 isn't a valid stream
+notepad.exe 7>&1
+
+# Operators
+if (10 -cgt 100) { }
+$a -is $b
+$b -contains $c
+$x -notcontains $c
+$a -match $b
+$a -notmatch $b
+$x -like $c
+100 -and 0
+$a -ceq 4 -and $a -ine $d -or 
+$c -is [Type]
+$c -isnot [Type]
+$c -as [Type]
+$k = $y -bor $k
+$x = $y -band $x
+$z = -bnot $x
+$k = $y -xor $b
+$k = $y -bxor $b
+$a -icontains $c
+$a -ccontains $c
+$a -iNotContains $c
+$a -cNotContains $c
+$a -cmatch $c
+$x -iMatch $c
+$x -iNotMatch $c
+$a -iLike $b
+$b -cLike $c
+"hey" -cgt "Hey"
+"Hey" -igt "hey"
+"hey" -cge "Hey"
+"Hey" -ige "hey"
+"HEY" -clt "hey"
+"HEY" -ilt "hey"
+"HEY" -cle "hey"
+"HEY" -ile "hey"
+
+# this isn't a valid operator:
+$x -foobar $y
+
+# Negative: these are cmdlets with unapproved verbs
+# we should not highlight keywords in them
+Foo-Is
+Foo-Not
+Foo-Join
+Foo-Bxor
+Foo-f
+Foo-eq
+Foo-match
+
+# format
+"{0:N2}" -f $a
+"{0:D8}" -f $a
+"{0:C2}" -f $a
+"{0:P0}" -f $a
+"{0:X0}" -f $a
+(1.11).tostring("#.#")
+"{1,10} {0,10} {2,10:x}" -f "First", "Second", 255
+("{0,6}" -f 4.99), ("{0,6:##.00}" -f 15.9)
+"{0:R}" -f (1mb/2.0)
+"{0:00.0}" -f 4.12341234
+"{0:##.#}" -f 4.12341234
+"{0:#,#.#}" -f 1234.121234
+"{0:##,,.000}" -f 1048576
+"{this is not a #comment}"
+"{0:##.#E000}" -f 2.71828
+"{0:#.00'##'}" -f 2.71828
+"{0:POS;NEG;ZERO}" -f -14
+"{0:$## Please}" -f 14
+"{0,-8:P1}" -f 1.75
+"{0,10:N3}{1,10:N3}{2,10:N3}{3,10:N3}" -f 0.2, 0.3, 0.45, 0.91
+'{0:00000.000}' -f 7.125
+
+# Help Directives (Comment based help)
+
+    # Should also be able to use with line comments
+    # .DESCRIPTION
+    # .EXAMPLE sdkl
+    # 
+    # .EXTERNALHELP some
+    # .REMOTEHELPRUNSPACE some
+    # .ExternalHelp some
+
+    <#
+        .DESCRIPTION
+        This is a description.
+        .REMOTEHELPRUNSPACE some
+        .example
+        .EXAMPLE
+        Get-Power 3 4
+        81
+
+        .ExternalHelp C:\MyScripts\Update-Month-Help.xml
+
+        .FORWARDHELPCATEGORY  Cmdlet
+
+        .FORWARDHELPTARGETNAME Get-Help
+
+        .INPUTS
+        None.
+
+        .LINK
+        Online version: http://www.acmecorp.com/widget.html
+        .LINK
+        Set-ProcedureName
+
+        .NOTES
+        Something.
+
+        .OUTPUTS
+        None unless the -PassThru switch parameter is used.
+
+        .PARAMETER ParameterName
+
+        .SYNOPSIS
+        Something.
+    #>
+
+# Misc test cases
+@("any","array","has").foreach({ $_ })
+@('any','array','has').foreach{ $_ }
+@("any","array","has").where({ $_.Length -gt 3 })
+@("any","array","has").where{ $_.Length -gt 3 }
+foo "$(x).exe"
+$file = join-path $env:SystemDrive "$([System.io.path]::GetRandomFileName()).ps1"
+$ScriptBlock | Out-File $file -Force
+workflow w1 {}
+Workflow work {}
+get-thing | Out-WithYou > $null # destroy
+"Escaped chars: `", `n, `$, `b, `t, `""
+'But here they''re not escape chars: `", `n, `$, `b, `"'
+"When you call a method: $( get-number | %{ invoke-command $( [string]::format("Like (this{0})","what?") ) $var } )"
+foo
+$a = $("Guess what, happens ""here, hey""" | "Hm... $("this, is" strange.) you can't really pipe to a string, but nevermind for now.")
+this-isnot.ps1
+a_mistake.here.ps1
+"anothermistake.ps1"
+$users.Split(',').Trim()
+TestConfiguration -OutputPath $workingDirectory
+"blablabla $(invoke-foo baz $a.bar) blablabla"
+invoke-foo baz $a.bar
+var
+-var
+_var
+jvar
+varj
+[ValidatePattern('^(?=^.{1,254}$)(^(?:(?!\d+\.)[a-zA-Z0-9_\-]{1,63}\.?)+(?:[a-zA-Z]{2,})$)')]
+$foo.bar
+($foo).bar
+(Invoke-Something).bar
+#comment
+some#comment # we need a space before the # for it to become a comment

--- a/examples/advancedFunction.ps1
+++ b/examples/advancedFunction.ps1
@@ -1,0 +1,78 @@
+<#
+.Synopsis
+   Short description
+.DESCRIPTION
+   Long description
+.EXAMPLE
+   Example of how to use this cmdlet
+.EXAMPLE
+   Another example of how to use this cmdlet
+.INPUTS
+   Inputs to this cmdlet (if any)
+.OUTPUTS
+   Output from this cmdlet (if any)
+.NOTES
+   General notes
+.COMPONENT
+   The component this cmdlet belongs to
+.ROLE
+   The role this cmdlet belongs to
+.FUNCTIONALITY
+   The functionality that best describes this cmdlet
+#>
+function Verb-Noun
+{
+    [CmdletBinding(DefaultParameterSetName='Parameter Set 1', 
+                  SupportsShouldProcess=$true, 
+                  PositionalBinding=$false,
+                  HelpUri = 'http://www.microsoft.com/',
+                  ConfirmImpact='Medium')]
+    [Alias()]
+    [OutputType([String])]
+    Param
+    (
+        # Param1 help description
+        [Parameter(Mandatory=$true, 
+                   ValueFromPipeline=$true,
+                   ValueFromPipelineByPropertyName=$true, 
+                   ValueFromRemainingArguments=$false, 
+                   Position=0,
+                   ParameterSetName='Parameter Set 1')]
+        [ValidateNotNull()]
+        [ValidateNotNullOrEmpty()]
+        [ValidateCount(0,5)]
+        [ValidateSet("sun", "moon", "earth")]
+        [Alias("p1")] 
+        $Param1,
+
+        # Param2 help description
+        [Parameter(ParameterSetName='Parameter Set 1')]
+        [AllowNull()]
+        [AllowEmptyCollection()]
+        [AllowEmptyString()]
+        [ValidateScript({$true})]
+        [ValidateRange(0,5)]
+        [int]
+        $Param2,
+
+        # Param3 help description
+        [Parameter(ParameterSetName='Another Parameter Set')]
+        [ValidatePattern("[a-z]*")]
+        [ValidateLength(0,15)]
+        [String]
+        $Param3
+    )
+
+    Begin
+    {
+    }
+    Process
+    {
+        if ($pscmdlet.ShouldProcess("Target", "Operation"))
+        {
+        }
+    }
+    End
+    {
+    }
+}

--- a/examples/class.ps1
+++ b/examples/class.ps1
@@ -1,0 +1,32 @@
+# Define a class
+class TypeName
+{
+   # Property with validate set
+   [ValidateSet("val1", "Val2")]
+   [string] $P1
+
+   # Static property
+   static [hashtable] $P2
+
+   # Hidden property does not show as result of Get-Member
+   hidden [int] $P3
+
+   # Constructor
+   TypeName ([string] $s)
+   {
+       $this.P1 = $s       
+   }
+
+   # Static method
+   static [void] MemberMethod1([hashtable] $h)
+   {
+       [TypeName]::P2 = $h
+   }
+
+   # Instance method
+   [int] MemberMethod2([int] $i)
+   {
+       $this.P3 = $i
+       return $this.P3
+   }
+}

--- a/examples/test.ps1
+++ b/examples/test.ps1
@@ -1,0 +1,284 @@
+# Testing PowerShell syntax highlighting rules.
+
+## Strings ##
+
+### Single quoted strings
+'Single quoted string.'
+'Single "quoted" string.'
+'Single ''quoted'' string.'
+'Single quoted #string.'
+'Single $quoted string.'
+
+### Double quoted strings
+"Double quoted string."
+"Double 'quoted' string."
+"Double ""quoted"" string."
+"Double `"quoted`" string."
+"Double quoted #string."
+"Double $quoted string."
+
+### Single quoted here-string
+@'
+Single quoted here-string.
+Single 'quoted' here-string.
+Single "quoted" here-string.
+Single quoted #here-string.
+Single $quoted here-string.
+'@
+
+### Double quoted here-string
+@"
+Double quoted here-string.
+Double "quoted" here-string.
+Double 'quoted' here-string.
+Double quoted #here-string.
+Double $quoted here-string.
+"@
+
+### Complex strings
+'^(?=^.{1,254}$)(^(?:(?!\d+\.)[a-zA-Z0-9_\-]{1,63}\.?)+(?:[a-zA-Z]{2,})$)'
+
+# This one currently fails. It's the exact same string as the one above. Uncomment to check.
+#[ValidatePattern('^(?=^.{1,254}$)(^(?:(?!\d+\.)[a-zA-Z0-9_\-]{1,63}\.?)+(?:[a-zA-Z]{2,})$)')]
+
+# Stop Parsing
+# Synatx highlighting should stop after --%, with the exception of the comment.
+command.exe -parameter 1 --% -parameter 2 /switch /par1:value # comment
+
+# Variables
+$name = 'value'
+"variable in a $string"
+"variable in a $($subExpression)"
+$global:name = 'value'
+$script:name = 'value'
+$local:name = 'value'
+$private:name = 'value'
+$using:name = 'value'
+${name} = 'value'
+${variable-name} = 'value'
+${#name} = 'value'
+${123} = 'value'
+${'name'} = 'value'
+${variable name} = 'value'
+${global: variable name} = 'value'
+${script:this`{value`}is} = 'valid' # don't currently work correctly
+$_ = $null
+$123 = 'value'
+$variable_name = 'value'
+$variable-name = 'value' # - in variable name is not allowed
+
+# Syntax highlighting not consistent in these two cases!
+$foo.bar
+($foo).bar
+
+# Sub Expression
+# Syntax highlighting not consistent in these two cases!
+"blablabla $(invoke-foo baz $a.bar) blablabla"
+invoke-foo baz $a.bar
+
+# Array Declaration
+@('One', 2, $three)
+('One', 2, $three)
+
+# Hash Table
+@{
+    Key = 'Value'
+    Key = 123
+    Key = $value
+}
+
+$ht = @{
+    Key = 'Value'
+    Key = 123
+    Key = $value
+}
+
+# Splatting
+Invoke-Something @parameters
+
+# Script Block
+{
+    'String'
+    Invoke-Something -p1 'value' -p2 $value
+}
+
+$sb = {
+    'String'
+    Invoke-Something -p1 'value' -p2 $value
+}
+
+# Types and .NET classes
+[string]$var = 'string'
+[system.string]$var = 'string'
+[int]$var = 100
+[uint64]$var = 100
+[System.String]::Empty
+[System.DateTime]::Parse('2016/09/21')
+
+# Numeric constants
+1
+9,9
+9.9
+10gb
+2/5kb
+
+# Numeric formatting
+# {index[,alignment][:formatString]}
+$a = 348 
+"{0:N2}" -f $a
+"{0:D8}" -f $a
+"{0:C2}" -f $a
+"{0:P0}" -f $a
+"{0:X0}" -f $a
+(1.11).tostring("#.#")
+"{1,10} {0,10} {2,10:x}" -f "First", "Second", 255
+("{0,6}" -f 4.99), ("{0,6:##.00}" -f 15.9)
+"{0:R}" -f (1mb/2.0)
+"{0:00.0}" -f 4.12341234
+"{0:##.#}" -f 4.12341234
+"{0:#,#.#}" -f 1234.121234
+"{0:##,,.000}" -f 1048576
+"{this is not a #comment}"
+"{0:##.#E000}" -f 2.71828
+"{0:#.00'##'}" -f 2.71828
+"{0:POS;NEG;ZERO}" -f -14
+"{0:$## Please}" -f 14
+"{0,-8:P1}" -f 1.75
+"{0,10:N3}{1,10:N3}{2,10:N3}{3,10:N3}" -f 0.2, 0.3, 0.45, 0.91
+'{0:00000.000}' -f 7.125
+
+# Operators
+$i = 0
+$i++
+$i += 10
+$a -band $b
+$x -gt $y
+$string -not $null
+$int -as [double]
+if (! $variable) {}
+if (-not $variable) {}
+$a -band $b
+$a -shr $b
+$a -eq $b
+$a -le $b
+$a -less $b # -less is not a valid operator and shouldn't be tagged and highlighted as such.
+
+# Parameters
+Write-Host -Message 'This is a message'
+Write-Host 'This is a message'
+Write-Host something something
+Get-WmiObject -Class Win32_OperatingSystem -ComputerName localhost | Select-Object -Property CSName,LastBootupTime
+
+# Functions and filters
+functioN MyFunction{}
+function My-Function         {}
+Function My.Function{}
+function My-Function.Other{}
+function Some.other.function{}
+FUNCTION MyFunction2 {}
+function MyFunction3
+{
+
+}
+function New-File { }
+function New-File ($Name) { }
+function NewFile($Name) { }
+functionMyFunction{}
+filter myfilter($param) {}
+Filter my-Filter ($param){}
+
+# This variant don't work properly
+function 
+#comment
+<# another comment #>
+test
+(
+    [string]
+    <# another comment #>
+    [parameter(mandatory)]
+    $s
+)
+{
+    "test $s"
+}
+
+# Enum
+enum myEnum
+{
+    listItem1
+    listItem2
+    listItem3
+}
+
+# - in enum name is not allowed
+enum my-Enum {
+    listItem1
+    listItem2
+    listItem3
+}
+
+# Class
+class myClass {}
+
+# - in class name is not allowed
+class my-Class {}
+
+# DSC
+configuration myConfiguration {
+	node web01, web02, web03 {
+
+	}
+}
+
+# Switch
+switch ($variable)
+{
+    'Value' {
+        return $false
+    }
+
+    default {
+        return $true
+    }
+}
+
+# Executable files
+. .\otherScript.ps1
+& cmd.exe
+c:\windows\system32\command.com
+c:\file.txt
+file.txt
+command.cmd
+co.cmd
+a.bat
+aa.bat
+aaa.bat
+aaaa.bat
+øyvind.ps1
+my file.exe
+
+# Comment based help and keywords
+# .ExternalHelp  psake.psm1-help.xml
+#Requires -Version 2.0
+
+<#
+	.PARAMETER
+	Something
+	.SYNOPSISIS
+	Something
+	.SYNOPSIS
+	.INPUTS
+#>
+
+# Methods
+# Only the first method name is highlighted correctly.
+$users.Split(',').Trim()
+
+# Other - strange cases
+[string]
+[string('string')]
+[string("string")]
+[string(Something = $true)]
+[Parameter(Something = $true)]
+string('string')
+'string'

--- a/examples/test.ps1
+++ b/examples/test.ps1
@@ -68,18 +68,26 @@ $variable_name = 'value'
 $variable-name = 'value' # - in variable name is not allowed
 $$
 
-# Syntax highlighting not consistent in these two cases!
+# Syntax highlighting not consistent in these cases!
 $foo.bar
 ($foo).bar
+(Invoke-Something).bar
 
 # Sub Expression
 # Syntax highlighting not consistent in these two cases!
 "blablabla $(invoke-foo baz $a.bar) blablabla"
 invoke-foo baz $a.bar
 
-# Array Declaration
+# Arrays
 @('One', 2, $three)
 ('One', 2, $three)
+$p = @(Get-Process Notepad)
+$a[0]
+$a[-3..-1]
+$a[0,2+4..6]
+,(1,2,3)
+,$a
+$t = $a[0,1 + 3..($a.length - 1)]
 
 # Hash Table
 @{
@@ -93,6 +101,8 @@ $ht = @{
     Key = 123
     Key = $value
 }
+
+$hash = [ordered]@{ Number = 1; Shape = "Square"; Color = "Blue"}
 
 # Splatting
 Invoke-Something @parameters
@@ -115,6 +125,7 @@ $sb = {
 [uint64]$var = 100
 [System.String]::Empty
 [System.DateTime]::Parse('2016/09/21')
+[int32[]]$ia = 1500,2230,3350,4000
 
 # Numeric constants
 1
@@ -187,6 +198,7 @@ function NewFile($Name) { }
 functionMyFunction{}
 filter myfilter($param) {}
 Filter my-Filter ($param){}
+function global:Invoke-Something {}
 
 # This variant don't work properly
 function 
@@ -274,6 +286,37 @@ my file.exe
 # Methods
 # Only the first method name is highlighted correctly.
 $users.Split(',').Trim()
+
+# Redirection
+# Examples from https://technet.microsoft.com/en-us/library/hh847746.aspx
+Get-Process > Process.txt
+dir *.ps1 >> Scripts.txt
+Get-Process none 2> Errors.txt
+Get-Process none 2>> Save-Errors.txt
+Get-Process none, Powershell 2>&1
+Write-Warning "Test!" 3> Warnings.txt
+Write-Warning "Test!" 3>> Save-Warnings.txt
+Test-Warning 3>&1
+Import-Module * -Verbose 4> Verbose.txt
+Import-Module * -Verbose 4>> Save-Verbose.txt
+Import-Module * -Verbose 4>&1
+Write-Debug "Starting" 5> Debug.txt
+Write-Debug "Saving" 5>> Save-Debug.txt
+Test-Debug 5>&1
+Test-Output *> Test-Output.txt
+Test-Output *>> Test-Output.txt
+Test-Output *>&1
+
+# Special characters
+"`0"
+for ($i = 0; $i -le 1; $i++){"`a"}
+"backup`b`b out"
+"There are two line breaks`n`nhere."
+Write-Host "Let's not move`rDelete everything before this point."
+"Column1`t`tColumn2`t`tColumn3"
+
+# Range
+Get-ChildItem c:\techdocs\[a-l]*.txt
 
 # Other - strange cases
 [string]

--- a/examples/test.ps1
+++ b/examples/test.ps1
@@ -66,6 +66,7 @@ $_ = $null
 $123 = 'value'
 $variable_name = 'value'
 $variable-name = 'value' # - in variable name is not allowed
+$$
 
 # Syntax highlighting not consistent in these two cases!
 $foo.bar

--- a/examples/test.ps1
+++ b/examples/test.ps1
@@ -265,7 +265,7 @@ switch ("fourteen") {}
 switch -CaseSensitive ("fourteen") {}
 switch -Illegal ("fourteen") {}
 switch -Regex ("fourteen") {}
-switch -Wildcard ("four*") {}
+switch -Wildcard ($a) {}
 switch -regex -file .\somefile.txt {}
 switch (3) {}
 switch (4, 2) {} 

--- a/examples/test.ps1
+++ b/examples/test.ps1
@@ -244,16 +244,31 @@ configuration myConfiguration {
 }
 
 # Switch
+# switch [-regex|-wildcard|-exact][-casesensitive] (<value>)
+# switch [-regex|-wildcard|-exact][-casesensitive] -file filename
 switch ($variable)
 {
     'Value' {
         return $false
     }
+    
+    2 {}
+    
+    {$value -le 100} {}
 
     default {
         return $true
     }
 }
+
+switch ("fourteen") {}
+switch -CaseSensitive ("fourteen") {}
+switch -Illegal ("fourteen") {}
+switch -Regex ("fourteen") {}
+switch -Wildcard ("four*") {}
+switch -regex -file .\somefile.txt {}
+switch (3) {}
+switch (4, 2) {} 
 
 # Executable files
 . .\otherScript.ps1
@@ -272,7 +287,7 @@ my file.exe
 
 # Comment based help and keywords
 # .ExternalHelp  psake.psm1-help.xml
-#Requires -Version 2.0
+#Requires -Version 2.0     # <-- should #Requires statements be highlighted differently?
 
 <#
 	.PARAMETER
@@ -308,6 +323,7 @@ Test-Output *>> Test-Output.txt
 Test-Output *>&1
 
 # Special characters
+# Should these be highlighted differently?
 "`0"
 for ($i = 0; $i -le 1; $i++){"`a"}
 "backup`b`b out"


### PR DESCRIPTION
This is all my commits since forking the main repository. It includes the first commits where I tried to fix the bugs in the matching rules, but at some point I decided to do a complete refactoring of the whole file.

Notable changes:
- Supports the Stop Parsing operator
- Added some illegal scopes (bad variable names and space after backtick ++)
- Moved almost all matching rules into the repository
- Grouped matching rules logically
- Added comments where I felt it was needed
- Much better command highlighting, with highlighting of parameters
- Workaround for highlighting the reserved word 'default' in switch-blocks (Will only highlight the word inside scriptblocks, so will also highlight in `{default}`
- Fixed highlighting of comment based help keywords
- More consequent highlighting of numerical constants
- Changed some scope names
- Better type highlighting
- Highlighting of keywords in classes
- Added highlighting of built-in aliases and executable files (.ps1, .exe etc)
- Added highlighting of some missing operators
- Better highlighting of properties/members
- Added test-files for testing syntax highlighting (in \examples)

Use these links to check before/after:
[Old](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_url=https%3A%2F%2Fgithub.com%2FPowerShell%2FEditorSyntax%2Fraw%2Fmaster%2FPowerShellSyntax.tmLanguage&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fraw.githubusercontent.com%2Fgravejester%2FEditorSyntax%2FRefactoring%2Fexamples%2FTheBigTestFile.ps1&code=) vs [New](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_url=https%3A%2F%2Fraw.githubusercontent.com%2Fgravejester%2FEditorSyntax%2FRefactoring%2FPowerShellSyntax.tmLanguage&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fraw.githubusercontent.com%2Fgravejester%2FEditorSyntax%2FRefactoring%2Fexamples%2FTheBigTestFile.ps1&code=)

