### PR TITLE
capture numerics

### DIFF
--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -656,7 +656,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>\b(0(?:x|X)[0-9a-fA-F_]+(?:U|u|L|l|UL|Ul|uL|ul|LU|Lu|lU|lu)?)((?i:[kmgtp]b)?)\b</string>
+					<string>(?<!\w)([-+]?0(?:x|X)[0-9a-fA-F_]+(?:U|u|L|l|UL|Ul|uL|ul|LU|Lu|lU|lu)?)((?i:[kmgtp]b)?)\b</string>
 					<key>name</key>
 					<string>constant.numeric.hexadecimal.powershell</string>
 				</dict>
@@ -675,7 +675,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>\b((?:[0-9_]+)?\.[0-9_]+(?:(?:e|E)[0-9]+)?(?:F|f|D|d|M|m)?)((?i:[kmgtp]b)?)\b</string>
+					<string>(?<!\w)([-+]?(?:[0-9_]+)?\.[0-9_]+(?:(?:e|E)[0-9]+)?(?:F|f|D|d|M|m)?)((?i:[kmgtp]b)?)\b</string>
 					<key>name</key>
 					<string>constant.numeric.scientific.powershell</string>
 				</dict>
@@ -694,7 +694,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>\b(0(?:b|B)[01_]+(?:U|u|L|l|UL|Ul|uL|ul|LU|Lu|lU|lu)?)((?i:[kmgtp]b)?)\b</string>
+					<string>(?<!\w)([-+]?0(?:b|B)[01_]+(?:U|u|L|l|UL|Ul|uL|ul|LU|Lu|lU|lu)?)((?i:[kmgtp]b)?)\b</string>
 					<key>name</key>
 					<string>constant.numeric.binary.powershell</string>
 				</dict>
@@ -713,7 +713,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>\b([0-9_]+(?:e|E)(?:[0-9_])?+(?:F|f|D|d|M|m)?)((?i:[kmgtp]b)?)\b</string>
+					<string>(?<!\w)([-+]?[0-9_]+(?:e|E)(?:[0-9_])?+(?:F|f|D|d|M|m)?)((?i:[kmgtp]b)?)\b</string>
 					<key>name</key>
 					<string>constant.numeric.decimal.powershell</string>
 				</dict>
@@ -732,7 +732,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>\b([0-9_]+\.(?:e|E)(?:[0-9_])?+(?:F|f|D|d|M|m)?)((?i:[kmgtp]b)?)\b</string>
+					<string>(?<!\w)([-+]?[0-9_]+\.(?:e|E)(?:[0-9_])?+(?:F|f|D|d|M|m)?)((?i:[kmgtp]b)?)\b</string>
 					<key>name</key>
 					<string>constant.numeric.decimal.powershell</string>
 				</dict>
@@ -751,7 +751,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>\b([0-9_]+[\.]?(?:F|f|D|d|M|m))((?i:[kmgtp]b)?)\b</string>
+					<string>(?<!\w)([-+]?[0-9_]+[\.]?(?:F|f|D|d|M|m))((?i:[kmgtp]b)?)\b</string>
 					<key>name</key>
 					<string>constant.numeric.decimal.powershell</string>
 				</dict>
@@ -770,7 +770,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>\b([0-9_]+[\.]?(?:U|u|L|l|UL|Ul|uL|ul|LU|Lu|lU|lu)?)((?i:[kmgtp]b)?)\b</string>
+					<string>(?<!\w)([-+]?[0-9_]+[\.]?(?:U|u|L|l|UL|Ul|uL|ul|LU|Lu|lU|lu)?)((?i:[kmgtp]b)?)\b</string>
 					<key>name</key>
 					<string>constant.numeric.decimal.powershell</string>
 				</dict>

--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -647,21 +647,16 @@
 						<key>1</key>
 						<dict>
 							<key>name</key>
-							<string>keyword.operator.math.powershell</string>
+							<string>constant.numeric.hexadecimal.powershell</string>
 						</dict>
 						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>support.constant.powershell</string>
-						</dict>
-						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>keyword.other.powershell</string>
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(?&lt;!\w)(?i:(0x)([a-f0-9]+)((?i:L)?(?i:[kmgtp]b)?))(?!\w)</string>
+					<string>\b(0(?:x|X)[0-9a-fA-F_]+(?:U|u|L|l|UL|Ul|uL|ul|LU|Lu|lU|lu)?)((?i:[kmgtp]b)?)\b</string>
 					<key>name</key>
 					<string>constant.numeric.hexadecimal.powershell</string>
 				</dict>
@@ -671,33 +666,113 @@
 						<key>1</key>
 						<dict>
 							<key>name</key>
-							<string>support.constant.powershell</string>
+							<string>constant.numeric.scientific.powershell</string>
 						</dict>
 						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.operator.math.powershell</string>
-						</dict>
-						<key>3</key>
-						<dict>
-							<key>name</key>
-							<string>support.constant.powershell</string>
-						</dict>
-						<key>4</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.other.powershell</string>
-						</dict>
-						<key>5</key>
 						<dict>
 							<key>name</key>
 							<string>keyword.other.powershell</string>
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(?&lt;!\w)(?i:(\d*\.?\d+)(?:((?i:E)[+-]?)(\d+))?((?i:[DL])?)((?i:[kmgtp]b)?))(?!\w)</string>
+					<string>\b((?:[0-9_]+)?\.[0-9_]+(?:(?:e|E)[0-9]+)?(?:F|f|D|d|M|m)?)((?i:[kmgtp]b)?)\b</string>
 					<key>name</key>
 					<string>constant.numeric.scientific.powershell</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>constant.numeric.binary.powershell</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.other.powershell</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>\b(0(?:b|B)[01_]+(?:U|u|L|l|UL|Ul|uL|ul|LU|Lu|lU|lu)?)((?i:[kmgtp]b)?)\b</string>
+					<key>name</key>
+					<string>constant.numeric.binary.powershell</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>constant.numeric.decimal.powershell</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.other.powershell</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>\b([0-9_]+(?:e|E)(?:[0-9_])?+(?:F|f|D|d|M|m)?)((?i:[kmgtp]b)?)\b</string>
+					<key>name</key>
+					<string>constant.numeric.decimal.powershell</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>constant.numeric.decimal.powershell</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.other.powershell</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>\b([0-9_]+\.(?:e|E)(?:[0-9_])?+(?:F|f|D|d|M|m)?)((?i:[kmgtp]b)?)\b</string>
+					<key>name</key>
+					<string>constant.numeric.decimal.powershell</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>constant.numeric.decimal.powershell</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.other.powershell</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>\b([0-9_]+[\.]?(?:F|f|D|d|M|m))((?i:[kmgtp]b)?)\b</string>
+					<key>name</key>
+					<string>constant.numeric.decimal.powershell</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>constant.numeric.decimal.powershell</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.other.powershell</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>\b([0-9_]+[\.]?(?:U|u|L|l|UL|Ul|uL|ul|LU|Lu|lU|lu)?)((?i:[kmgtp]b)?)\b</string>
+					<key>name</key>
+					<string>constant.numeric.decimal.powershell</string>
 				</dict>
 			</array>
 		</dict>
@@ -1192,4 +1267,3 @@
 	<string>f8f5ffb0-503e-11df-9879-0800200c9a66</string>
 </dict>
 </plist>
-

--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -656,7 +656,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(?<!\w)([-+]?0(?:x|X)[0-9a-fA-F_]+(?:U|u|L|l|UL|Ul|uL|ul|LU|Lu|lU|lu)?)((?i:[kmgtp]b)?)\b</string>
+					<string>(?&lt;!\w)([-+]?0(?:x|X)[0-9a-fA-F_]+(?:U|u|L|l|UL|Ul|uL|ul|LU|Lu|lU|lu)?)((?i:[kmgtp]b)?)\b</string>
 					<key>name</key>
 					<string>constant.numeric.hexadecimal.powershell</string>
 				</dict>
@@ -675,7 +675,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(?<!\w)([-+]?(?:[0-9_]+)?\.[0-9_]+(?:(?:e|E)[0-9]+)?(?:F|f|D|d|M|m)?)((?i:[kmgtp]b)?)\b</string>
+					<string>(?&lt;!\w)([-+]?(?:[0-9_]+)?\.[0-9_]+(?:(?:e|E)[0-9]+)?(?:F|f|D|d|M|m)?)((?i:[kmgtp]b)?)\b</string>
 					<key>name</key>
 					<string>constant.numeric.scientific.powershell</string>
 				</dict>
@@ -694,7 +694,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(?<!\w)([-+]?0(?:b|B)[01_]+(?:U|u|L|l|UL|Ul|uL|ul|LU|Lu|lU|lu)?)((?i:[kmgtp]b)?)\b</string>
+					<string>(?&lt;!\w)([-+]?0(?:b|B)[01_]+(?:U|u|L|l|UL|Ul|uL|ul|LU|Lu|lU|lu)?)((?i:[kmgtp]b)?)\b</string>
 					<key>name</key>
 					<string>constant.numeric.binary.powershell</string>
 				</dict>
@@ -713,7 +713,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(?<!\w)([-+]?[0-9_]+(?:e|E)(?:[0-9_])?+(?:F|f|D|d|M|m)?)((?i:[kmgtp]b)?)\b</string>
+					<string>(?&lt;!\w)([-+]?[0-9_]+(?:e|E)(?:[0-9_])?+(?:F|f|D|d|M|m)?)((?i:[kmgtp]b)?)\b</string>
 					<key>name</key>
 					<string>constant.numeric.decimal.powershell</string>
 				</dict>
@@ -732,7 +732,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(?<!\w)([-+]?[0-9_]+\.(?:e|E)(?:[0-9_])?+(?:F|f|D|d|M|m)?)((?i:[kmgtp]b)?)\b</string>
+					<string>(?&lt;!\w)([-+]?[0-9_]+\.(?:e|E)(?:[0-9_])?+(?:F|f|D|d|M|m)?)((?i:[kmgtp]b)?)\b</string>
 					<key>name</key>
 					<string>constant.numeric.decimal.powershell</string>
 				</dict>
@@ -751,7 +751,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(?<!\w)([-+]?[0-9_]+[\.]?(?:F|f|D|d|M|m))((?i:[kmgtp]b)?)\b</string>
+					<string>(?&lt;!\w)([-+]?[0-9_]+[\.]?(?:F|f|D|d|M|m))((?i:[kmgtp]b)?)\b</string>
 					<key>name</key>
 					<string>constant.numeric.decimal.powershell</string>
 				</dict>
@@ -770,7 +770,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(?<!\w)([-+]?[0-9_]+[\.]?(?:U|u|L|l|UL|Ul|uL|ul|LU|Lu|lU|lu)?)((?i:[kmgtp]b)?)\b</string>
+					<string>(?&lt;!\w)([-+]?[0-9_]+[\.]?(?:U|u|L|l|UL|Ul|uL|ul|LU|Lu|lU|lu)?)((?i:[kmgtp]b)?)\b</string>
 					<key>name</key>
 					<string>constant.numeric.decimal.powershell</string>
 				</dict>


### PR DESCRIPTION
Using the following in a .tmTheme file:

```xml
<dict>
	<key>name</key>
	<string>Number</string>
	<key>scope</key>
	<string>constant.numeric</string>
	<key>settings</key>
	<dict>
		<key>fontStyle</key>
		<string></string>
		<key>foreground</key>
		<string>#F00</string>
	</dict>
</dict>
```
to make numerics bright red for testing. The result is this:

![numeric-before](https://user-images.githubusercontent.com/12937335/39545762-6c1adb56-4e0f-11e8-8d87-e189a43f4671.png)

because they're being coloured by the `keyword` scope.

I am proposing something closer to how it's handled in the [C# language syntax](https://github.com/dotnet/csharp-tmLanguage) file which more accurately represents numerics and allows theming within the `constant.numeric` scope.

![numeric-after](https://user-images.githubusercontent.com/12937335/39545897-d81f1c9a-4e0f-11e8-9d02-d14ad1cc47e9.png)