### PR TITLE
splatting variable highlighting.

### DIFF
--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -875,7 +875,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(?i:(\$)(global|local|private|script|using|workflow):((?:\p{L}|\d|_)+))((?:\.(?:\p{L}|\d|_)+)*\b)?</string>
+					<string>(?i:(\$|@)(global|local|private|script|using|workflow):((?:\p{L}|\d|_)+))((?:\.(?:\p{L}|\d|_)+)*\b)?</string>
 				</dict>
 				<dict>
 					<key>captures</key>
@@ -934,7 +934,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(?i:(\$)((?:\p{L}|\d|_)+:)?((?:\p{L}|\d|_)+))((?:\.(?:\p{L}|\d|_)+)*\b)?</string>
+					<string>(?i:(\$|@)((?:\p{L}|\d|_)+:)?((?:\p{L}|\d|_)+))((?:\.(?:\p{L}|\d|_)+)*\b)?</string>
 				</dict>
 				<dict>
 					<key>captures</key>
@@ -1090,7 +1090,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(?i:(\$)(global|local|private|script|using|workflow):((?:\p{L}|\d|_)+))</string>
+					<string>(?i:(\$|@)(global|local|private|script|using|workflow):((?:\p{L}|\d|_)+))</string>
 				</dict>
 				<dict>
 					<key>captures</key>


### PR DESCRIPTION
Quick fix to correct the highlighting of splat variables. (reported by /u/da_chicken on reddit.)

Before:
![splatting-before](https://user-images.githubusercontent.com/12937335/39591408-ec14dd46-4ec0-11e8-8a93-415ec137694a.png)

After:
![splatting-after](https://user-images.githubusercontent.com/12937335/39591405-e9e9d31e-4ec0-11e8-8d37-35ea94eb0289.png)

Need to eventually rework how variables are scoped but this covers splatting for now.