### PR TITLE
Expand keyword list for comment help

### DIFF
--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -455,7 +455,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(?i:\s*(\.)(SYNOPSIS|DESCRIPTION|EXAMPLE|INPUTS|OUTPUTS|NOTES|LINK|COMPONENT|FUNCTIONALITY))</string>
+					<string>(?i:\s*(\.)(COMPONENT|DESCRIPTION|EXAMPLE|EXTERNALHELP|FORWARDHELPCATEGORY|FORWARDHELPTARGETNAME|FUNCTIONALITY|INPUTS|LINK|NOTES|OUTPUTS|REMOTEHELPRUNSPACE|ROLE|SYNOPSIS))</string>
 					<key>name</key>
 					<string>comment.documentation.embedded.powershell</string>
 				</dict>


### PR DESCRIPTION
Minor change to capture commend based help keywords that were missed such as `.ROLE`. The new list covers all keywords in about_Comment_Based_Help for all versions including v6.