### PR TITLE
Using, Requires, Hidden, and Static

### DIFF
--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -1072,7 +1072,7 @@
 						<key>0</key>
 						<dict>
 							<key>name</key>
-							<string>meta.requires</string>
+							<string>meta.requires.powershell</string>
 						</dict>
 						<key>1</key>
 						<dict>
@@ -1099,7 +1099,7 @@
 						<key>0</key>
 						<dict>
 							<key>name</key>
-							<string>meta.requires</string>
+							<string>meta.requires.powershell</string>
 						</dict>
 						<key>1</key>
 						<dict>
@@ -1126,7 +1126,7 @@
 						<key>0</key>
 						<dict>
 							<key>name</key>
-							<string>meta.requires</string>
+							<string>meta.requires.powershell</string>
 						</dict>
 						<key>1</key>
 						<dict>
@@ -1148,7 +1148,7 @@
 						<key>0</key>
 						<dict>
 							<key>name</key>
-							<string>meta.requires</string>
+							<string>meta.requires.powershell</string>
 						</dict>
 						<key>1</key>
 						<dict>
@@ -1175,7 +1175,7 @@
 						<key>0</key>
 						<dict>
 							<key>name</key>
-							<string>meta.requires</string>
+							<string>meta.requires.powershell</string>
 						</dict>
 						<key>1</key>
 						<dict>

--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -250,9 +250,17 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>(?&lt;!\w)((?i:begin|break|catch|continue|data|define|do|dynamicparam|else|elseif|end|exit|finally|for|foreach(?!-object)|from|hidden|if|in|inlinescript|parallel|param|process|return|static|switch|throw|trap|try|until|var|where(?!-object)|while)|%|\?)(?!\w)</string>
+			<string>(?&lt;!\w)((?i:begin|break|catch|continue|data|define|do|dynamicparam|else|elseif|end|exit|finally|for|foreach(?!-object)|from|if|in|inlinescript|parallel|param|process|return|switch|throw|trap|try|until|var|where(?!-object)|while)|%|\?)(?!\w)</string>
 			<key>name</key>
 			<string>keyword.control.powershell</string>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>This should only be relevant inside a class but will require a rework of how classes are matched. This is a temp fix.</string>
+			<key>match</key>
+			<string>(?&lt;!\w)((?i:hidden|static))(?!\w)</string>
+			<key>name</key>
+			<string>storage.modifier.powershell</string>
 		</dict>
 		<dict>
 			<key>captures</key>
@@ -1052,23 +1060,23 @@
 		<key>UsingDirective</key>
 		<dict>
 			<key>match</key>
-			<string>(?&lt;!\w)(?i:(using))\s+(?i:(namespace|module))?\s+(?i:((?:\w+(?:\.)?)+))</string>
+			<string>(?&lt;!\w)(?i:(using))\s+(?i:(namespace|module))\s+(?i:((?:\w+(?:\.)?)+))</string>
 			<key>captures</key>
 			<dict>
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>keyword.other.using.powershell</string>
+					<string>keyword.control.using.powershell</string>
 				</dict>
 				<key>2</key>
 				<dict>
 					<key>name</key>
-					<string>keyword.control.powershell</string>
+					<string>keyword.other.powershell</string>
 				</dict>
 				<key>3</key>
 				<dict>
 					<key>name</key>
-					<string>entity.name.type.powershell</string>
+					<string>variable.parameter.powershell</string>
 				</dict>
 			</dict>
 		</dict>

--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -86,6 +86,10 @@
 		</dict>
 		<dict>
 			<key>include</key>
+			<string>#UsingDirective</string>
+		</dict>
+		<dict>
+			<key>include</key>
 			<string>#type</string>
 		</dict>
 		<dict>
@@ -246,7 +250,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>(?&lt;!\w)((?i:begin|break|catch|continue|data|define|do|dynamicparam|else|elseif|end|exit|finally|for|foreach(?!-object)|from|hidden|if|in|inlinescript|parallel|param|process|return|switch|throw|trap|try|until|using|var|where(?!-object)|while)|%|\?)(?!\w)</string>
+			<string>(?&lt;!\w)((?i:begin|break|catch|continue|data|define|do|dynamicparam|else|elseif|end|exit|finally|for|foreach(?!-object)|from|hidden|if|in|inlinescript|parallel|param|process|return|switch|throw|trap|try|until|var|where(?!-object)|while)|%|\?)(?!\w)</string>
 			<key>name</key>
 			<string>keyword.control.powershell</string>
 		</dict>
@@ -969,6 +973,29 @@
 					<string>(?i:(\$\{)((?:\p{L}|\d|_)+:)?([^}]*[^}`])(\}))((?:\.(?:\p{L}|\d|_)+)*\b)?</string>
 				</dict>
 			</array>
+		</dict>
+		<key>UsingDirective</key>
+		<dict>
+			<key>match</key>
+			<string>(?&lt;!\w)(?i:(using))\s+(?i:(namespace|module))?\s+(?i:((?:\w+(?:\.)?)+))</string>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.other.using.powershell</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.control.powershell</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.type.powershell</string>
+				</dict>
+			</dict>
 		</dict>
 		<key>variableNoProperty</key>
 		<dict>

--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -56,6 +56,10 @@
 					<key>include</key>
 					<string>#commentEmbeddedDocs</string>
 				</dict>
+				<dict>
+					<key>include</key>
+					<string>#RequiresDirective</string>
+				</dict>
 			</array>
 		</dict>
 		<dict>
@@ -492,30 +496,6 @@
 					</dict>
 					<key>match</key>
 					<string>(?i:\s*(\.)(PARAMETER|FORWARDHELPTARGETNAME|FORWARDHELPCATEGORY|REMOTEHELPRUNSPACE|EXTERNALHELP)\s+([a-z0-9-_]+))</string>
-					<key>name</key>
-					<string>comment.documentation.embedded.powershell</string>
-				</dict>
-				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>constant.string.documentation.powershell</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.operator.documentation.powershell</string>
-						</dict>
-						<key>3</key>
-						<dict>
-							<key>name</key>
-							<string>string.quoted.double.heredoc.powershell</string>
-						</dict>
-					</dict>
-					<key>match</key>
-					<string>(?i:requires\s+-(Version\s+\d(.\d+)?|Assembly\s+(.*)|Module\s+(.*)|PsSnapIn\s+(.*)|ShellId\s+(.*)))</string>
 					<key>name</key>
 					<string>comment.documentation.embedded.powershell</string>
 				</dict>
@@ -1079,6 +1059,152 @@
 					<string>variable.parameter.powershell</string>
 				</dict>
 			</dict>
+		</dict>
+		<key>RequiresDirective</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>(?i:(requires))\s(?i:(-Modules))\s(((?:\w+)\,?\s?){1,})$</string>
+					<key>captures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>meta.requires</string>
+						</dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.control.requires.powershell</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.other.powershell</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>variable.parameter.powershell</string>
+						</dict>
+					</dict>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>(?i:(requires))\s(?i:(-ShellId))\s(\w+)$</string>
+					<key>captures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>meta.requires</string>
+						</dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.control.requires.powershell</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.other.powershell</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>variable.parameter.powershell</string>
+						</dict>
+					</dict>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>(?i:(requires))\s(?i:(-RunAsAdministrator))$</string>
+					<key>captures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>meta.requires</string>
+						</dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.control.requires.powershell</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.other.powershell</string>
+						</dict>
+					</dict>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>(?i:(requires))\s(?i:(-Version))\s((?:\d\.?){1,})$</string>
+					<key>captures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>meta.requires</string>
+						</dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.control.requires.powershell</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.other.powershell</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>variable.parameter.powershell</string>
+						</dict>
+					</dict>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>(?i:(requires))(?:\s(-PSSnapin)\s(\w+))(?:\s(?i:(-Version))\s((?:\d\.?){1,}))?$</string>
+					<key>captures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>meta.requires</string>
+						</dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.control.requires.powershell</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.other.powershell</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>variable.parameter.powershell</string>
+						</dict>
+						<key>4</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.other.powershell</string>
+						</dict>
+						<key>5</key>
+						<dict>
+							<key>name</key>
+							<string>variable.parameter.powershell</string>
+						</dict>
+					</dict>
+				</dict>
+			</array>
 		</dict>
 		<key>variableNoProperty</key>
 		<dict>

--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -246,7 +246,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>(?&lt;!\w)((?i:begin|break|catch|continue|data|define|do|dynamicparam|else|elseif|end|exit|finally|for|foreach(?!-object)|from|if|in|inlinescript|parallel|param|process|return|switch|throw|trap|try|until|using|var|where(?!-object)|while)|%|\?)(?!\w)</string>
+			<string>(?&lt;!\w)((?i:begin|break|catch|continue|data|define|do|dynamicparam|else|elseif|end|exit|finally|for|foreach(?!-object)|from|hidden|if|in|inlinescript|parallel|param|process|return|switch|throw|trap|try|until|using|var|where(?!-object)|while)|%|\?)(?!\w)</string>
 			<key>name</key>
 			<string>keyword.control.powershell</string>
 		</dict>

--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -250,7 +250,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>(?&lt;!\w)((?i:begin|break|catch|continue|data|define|do|dynamicparam|else|elseif|end|exit|finally|for|foreach(?!-object)|from|hidden|if|in|inlinescript|parallel|param|process|return|switch|throw|trap|try|until|var|where(?!-object)|while)|%|\?)(?!\w)</string>
+			<string>(?&lt;!\w)((?i:begin|break|catch|continue|data|define|do|dynamicparam|else|elseif|end|exit|finally|for|foreach(?!-object)|from|hidden|if|in|inlinescript|parallel|param|process|return|static|switch|throw|trap|try|until|var|where(?!-object)|while)|%|\?)(?!\w)</string>
 			<key>name</key>
 			<string>keyword.control.powershell</string>
 		</dict>

--- a/examples/TheBigTestFile.ps1
+++ b/examples/TheBigTestFile.ps1
@@ -1,3 +1,17 @@
+using namespace System.Management.Automation
+#Requires -PSSnapin DiskSnapin -Version 1.2
+#Requires -PSSnapin DiskSnapin
+#Requires -Version 3
+#Requires -Version 3.0
+#Requires -RunAsAdministrator
+#Requires -Modules PSWorkflow
+#Requires -Modules PSWorkflow, ActiveDirectory
+#Requires -ShellId MyLocalShell
+#Requires -Modules @{
+    ModuleName="PSScheduledJob"
+    ModuleVersion="1.0.0.0"
+}
+
 throw "Do not run this file!"
 
 <#
@@ -194,7 +208,7 @@ switch -Regex ("fourteen") {}
 switch -Wildcard ($a) {}
 switch -regex -file .\somefile.txt {}
 switch (3) {}
-switch (4, 2) {} 
+switch (4, 2) {}
 
 switch -Regex -File $filePath {
     '.' {}
@@ -213,7 +227,7 @@ switch ('this') {
 
 # Illegal backtick
 Invoke-Command -arg1 $val1 `
-	           -arg2 $val2 ` 
+	           -arg2 $val2 `
 
 # Functions and filters
 functioN MyFunction{}
@@ -234,14 +248,14 @@ filter myfilter($param) {}
 Filter my-Filter ($param){}
 
 function foo
-#comment 
+#comment
 {
-    
+
 }
 
 # This one will not highlight the function name,
 # because of the comments after 'function'. TODO?
-function 
+function
 <# another comment #>
 test
 (
@@ -261,15 +275,15 @@ function Test-Drive([string]$roman) {
 
 function Get-EscapedPath
 {
-    param( 
+    param(
     [Parameter(
-        Position=0, 
+        Position=0,
         Mandatory=$true
         ValueFromPipeline=$true,
         ValueFromPipelineByPropertyName=$true)
     ]
     [string]$path
-    ) 
+    )
 
     process {
         if ($path.Contains(' '))
@@ -326,7 +340,7 @@ class Car: Vehicle {
 
     SetLength([int]$Length) {
         $this.Length = $Length
-    } 
+    }
 }
 
 # Illegal class name
@@ -373,7 +387,7 @@ $a -match $b
 $a -notmatch $b
 $x -like $c
 100 -and 0
-$a -ceq 4 -and $a -ine $d -or 
+$a -ceq 4 -and $a -ine $d -or
 $c -is [Type]
 $c -isnot [Type]
 $c -as [Type]
@@ -441,7 +455,7 @@ Foo-match
     # Should also be able to use with line comments
     # .DESCRIPTION
     # .EXAMPLE sdkl
-    # 
+    #
     # .EXTERNALHELP some
     # .REMOTEHELPRUNSPACE some
     # .ExternalHelp some

--- a/examples/advancedFunction.ps1
+++ b/examples/advancedFunction.ps1
@@ -1,3 +1,5 @@
+using module Microsoft.PowerShell.Management
+
 <#
 .Synopsis
    Short description
@@ -22,8 +24,8 @@
 #>
 function Verb-Noun
 {
-    [CmdletBinding(DefaultParameterSetName='Parameter Set 1', 
-                  SupportsShouldProcess=$true, 
+    [CmdletBinding(DefaultParameterSetName='Parameter Set 1',
+                  SupportsShouldProcess=$true,
                   PositionalBinding=$false,
                   HelpUri = 'http://www.microsoft.com/',
                   ConfirmImpact='Medium')]
@@ -32,17 +34,17 @@ function Verb-Noun
     Param
     (
         # Param1 help description
-        [Parameter(Mandatory=$true, 
+        [Parameter(Mandatory=$true,
                    ValueFromPipeline=$true,
-                   ValueFromPipelineByPropertyName=$true, 
-                   ValueFromRemainingArguments=$false, 
+                   ValueFromPipelineByPropertyName=$true,
+                   ValueFromRemainingArguments=$false,
                    Position=0,
                    ParameterSetName='Parameter Set 1')]
         [ValidateNotNull()]
         [ValidateNotNullOrEmpty()]
         [ValidateCount(0,5)]
         [ValidateSet("sun", "moon", "earth")]
-        [Alias("p1")] 
+        [Alias("p1")]
         $Param1,
 
         # Param2 help description

--- a/examples/class.ps1
+++ b/examples/class.ps1
@@ -1,3 +1,5 @@
+using namespace system.management.automation
+
 # Define a class
 class TypeName
 {
@@ -14,7 +16,7 @@ class TypeName
    # Constructor
    TypeName ([string] $s)
    {
-       $this.P1 = $s       
+       $this.P1 = $s
    }
 
    # Static method

--- a/tools/package.json
+++ b/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "editorsyntax",
-  "license" : "MIT",
+  "license": "MIT",
   "description": "PowerShell language syntax",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This contains three fixes:

- `using module/namespace` declaration. 

![using](https://user-images.githubusercontent.com/12937335/39676638-842bb94e-512b-11e8-8316-2138e1459c0f.png)

```
using namespace System.Xml
^ - keyword.control.using.powershell
      ^ - keyword.other.powershell
                ^ - variable.parameter.powershell
```

- `hidden`/`static` modifiers within classes. (`storage.modifier.powershell`)

![hidden-static](https://user-images.githubusercontent.com/12937335/39676644-9b36e6ae-512b-11e8-96e2-d2e90bad192a.png)

- `#requires` declaration 

I have fixed the issues with -Version in requires showing different highlighting after a period and added scopes to the various parts of the statement in line with `using`.

```
#Requires -Version 3.0
^ - comment.line.number-sign.powershell
 ^ - keyword.control.requires.powershell
          ^ - keyword.other.powershell
                  ^ - variable.parameter.powershell
```

Use of hashtables in `-Modules` still needs to be fixed but will require work on the scoping of hashtables first.

![requires](https://user-images.githubusercontent.com/12937335/39677418-8e7fead0-5137-11e8-8044-17568345fd1d.png)

(screenshot using a different theme from previous two.)

fixes #20