### PR TITLE
scriptblocks within hashtables.

### DIFF
--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -1388,6 +1388,10 @@
 				</dict>
 				<dict>
 					<key>include</key>
+					<string>#scriptblock</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>$self</string>
 				</dict>
 			</array>


### PR DESCRIPTION
Correct highlighting of open scriptblocks within hashtables.

![hashtable-scriptblock](https://user-images.githubusercontent.com/12937335/39719902-e0225e02-51f7-11e8-87d6-870c67dd7091.png)

fixes #86 