### PR TITLE
Fixes broken comment highlighting

### DIFF
--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -1083,7 +1083,7 @@
 		<key>RequiresDirective</key>
 		<dict>
 			<key>begin</key>
-			<string>(?i:(requires))\s</string>
+			<string>(?<=#)(?i:(requires))\s</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>0</key>


### PR DESCRIPTION
Fixes broken comment highlighting when *requires* word is used in middle of text.

**Before Fix:**

![image](https://user-images.githubusercontent.com/16168755/39755034-9728c240-52c4-11e8-9263-1bda0e42519b.png)

**After Fix:**

![image](https://user-images.githubusercontent.com/16168755/39755062-b6122426-52c4-11e8-9c54-43427fa6b606.png)
