### PR TITLE
Fixes CommandType argument highlighting

### DIFF
--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -542,7 +542,7 @@
 		<key>function</key>
 		<dict>
 			<key>begin</key>
-			<string>(?&lt;!\S)(?i)(function|filter|configuration|workflow)\s+(?:(global|local|script|private):)?((?:\p{L}|\d|_|-|\.)+)</string>
+			<string>^(?:\s*+)(?i)(function|filter|configuration|workflow)\s+(?:(global|local|script|private):)?((?:\p{L}|\d|_|-|\.)+)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>0</key>


### PR DESCRIPTION
*Function*, *Filter*, *Configuration* and *Workflow* keywords are highlighted when used as arguments for *CommandType* parameter.

**Before fix:**

![image](https://user-images.githubusercontent.com/16168755/39845160-94ed9d6c-53f4-11e8-8d2e-fe16cd5d05ce.png)

**After fix:**

![image](https://user-images.githubusercontent.com/16168755/39845188-bb1c16c6-53f4-11e8-9dc1-079d6ccc4cec.png)

