### PR TITLE
remove duplicate matches for comparison

### DIFF
--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -236,12 +236,6 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>(?&lt;!\w)-([ci]?[lg][te]|eq|ne)</string>
-			<key>name</key>
-			<string>keyword.operator.logical.powershell</string>
-		</dict>
-		<dict>
-			<key>match</key>
 			<string>(\b(([A-Za-z0-9\-_\.]+)\.(?i:exe|com|cmd|bat))\b)</string>
 			<key>name</key>
 			<string>support.function.powershell</string>

--- a/spec/testfiles/syntax_test_TheBigTestFile.ps1
+++ b/spec/testfiles/syntax_test_TheBigTestFile.ps1
@@ -962,7 +962,7 @@ if (10 -cgt 100) { }
 # <- keyword.control.powershell
 #  ^ punctuation.section.group.begin.powershell
 #   ^^      ^^^ constant.numeric.integer.powershell
-#      ^^^^ keyword.operator.logical.powershell
+#      ^^^^ keyword.operator.comparison.powershell
 #              ^ punctuation.section.group.end.powershell
 #                ^ punctuation.section.braces.begin.powershell
 #                  ^  punctuation.section.braces.end.powershell
@@ -1029,21 +1029,21 @@ $a -iLike $b
 $b -cLike $c
 #  ^ keyword.operator.comparison.powershell
 "hey" -cgt "Hey"
-#     ^ keyword.operator.logical.powershell
+#     ^ keyword.operator.comparison.powershell
 "Hey" -igt "hey"
-#     ^ keyword.operator.logical.powershell
+#     ^ keyword.operator.comparison.powershell
 "hey" -cge "Hey"
-#     ^ keyword.operator.logical.powershell
+#     ^ keyword.operator.comparison.powershell
 "Hey" -ige "hey"
-#     ^ keyword.operator.logical.powershell
+#     ^ keyword.operator.comparison.powershell
 "HEY" -clt "hey"
-#     ^ keyword.operator.logical.powershell
+#     ^ keyword.operator.comparison.powershell
 "HEY" -ilt "hey"
-#     ^ keyword.operator.logical.powershell
+#     ^ keyword.operator.comparison.powershell
 "HEY" -cle "hey"
-#     ^ keyword.operator.logical.powershell
+#     ^ keyword.operator.comparison.powershell
 "HEY" -ile "hey"
-#     ^ keyword.operator.logical.powershell
+#     ^ keyword.operator.comparison.powershell
 
 # format
     "{0:N2}" -f $a


### PR DESCRIPTION
Resolves #54. Comparison operators were covered twice:

```
<dict>	
	<key>match</key>	
	<string>(?&lt;!\w)-([ci]?[lg][te]|eq|ne)</string>	
	<key>name</key>	
	<string>keyword.operator.logical.powershell</string>	
</dict>
```

and

```
<dict>
	<key>match</key>
	<string>(?&lt;!\w)-(?i:[ic]?(?:eq|ne|[gl][te]|(?:not)?(?:like|match|contains|in)|replace))(?!\p{L})</string>
	<key>name</key>
	<string>keyword.operator.comparison.powershell</string>
</dict>
```

Removed the less complete of the duplicates:

![length](https://user-images.githubusercontent.com/12937335/40326994-811fb366-5cfe-11e8-8af3-8f7324f8e139.png)
