### PR TITLE
Fix process keyword coloring

### DIFF
--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -248,7 +248,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>(?&lt;!\w|-)((?i:begin|break|catch|continue|data|default|define|do|dynamicparam|else|elseif|end|exit|finally|for|foreach(?!-object)|from|if|in|inlinescript|parallel|param|process|return|switch|throw|trap|try|until|var|where(?!-object)|while)|%|\?)(?!\w)</string>
+			<string>(?&lt;![\w-\.])((?i:begin|break|catch|continue|data|default|define|do|dynamicparam|else|elseif|end|exit|finally|for|foreach(?!-object)|from|if|in|inlinescript|parallel|param|process|return|switch|throw|trap|try|until|var|where(?!-object)|while)|%|\?)(?!\w)</string>
 			<key>name</key>
 			<string>keyword.control.powershell</string>
 		</dict>


### PR DESCRIPTION
Fixes process keyword coloring when used as part of namespace (#47)

**Before:**

![image](https://user-images.githubusercontent.com/16168755/40535114-79fec61e-6008-11e8-9c31-784015b182f7.png)

**After:**

![image](https://user-images.githubusercontent.com/16168755/40535086-5fc6b27a-6008-11e8-8345-71a90e928a29.png)
