### PR TITLE
Fix process keyword coloring

### DIFF
--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -248,7 +248,13 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>(?&lt;!\w|-|\.)((?i:begin|break|catch|continue|data|default|define|do|dynamicparam|else|elseif|end|exit|finally|for|foreach(?!-object)|from|if|in|inlinescript|parallel|param|process|return|switch|throw|trap|try|until|var|where(?!-object)|while)|%|\?)(?!\w)</string>
+			<string>(?&lt;!\w|-|\.)((?i:begin|break|catch|continue|data|default|define|do|dynamicparam|else|elseif|end|exit|finally|for|foreach-object|from|if|in|inlinescript|parallel|param|process|return|switch|throw|trap|try|until|var|where-object|while)|%|\?)(?!\w)</string>
+			<key>name</key>
+			<string>keyword.control.powershell</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>(?&lt;!\w|-|[^\)]\.)((?i:foreach|where)|%|\?)(?!\w)</string>
 			<key>name</key>
 			<string>keyword.control.powershell</string>
 		</dict>

--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -248,13 +248,13 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>(?&lt;!\w|-|\.)((?i:begin|break|catch|continue|data|default|define|do|dynamicparam|else|elseif|end|exit|finally|for|foreach-object|from|if|in|inlinescript|parallel|param|process|return|switch|throw|trap|try|until|var|where-object|while)|%|\?)(?!\w)</string>
+			<string>(?&lt;!\w|-|\.)((?i:begin|break|catch|continue|data|default|define|do|dynamicparam|else|elseif|end|exit|finally|for|from|if|in|inlinescript|parallel|param|process|return|switch|throw|trap|try|until|var|while)|%|\?)(?!\w)</string>
 			<key>name</key>
 			<string>keyword.control.powershell</string>
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>(?&lt;!\w|-|[^\)]\.)((?i:foreach|where)|%|\?)(?!\w)</string>
+			<string>(?&lt;!\w|-|[^\)]\.)((?i:(foreach|where)(?!-object))|%|\?)(?!\w)</string>
 			<key>name</key>
 			<string>keyword.control.powershell</string>
 		</dict>

--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -248,7 +248,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>(?&lt;!\w|-)((?i:begin|break|catch|continue|data|default|define|do|dynamicparam|else|elseif|end|exit|finally|for|foreach(?!-object)|from|if|in|inlinescript|parallel|param|process|return|switch|throw|trap|try|until|var|where(?!-object)|while)|%|\?)(?!\w)</string>
+			<string>(?&lt;!\w|-|\.)((?i:begin|break|catch|continue|data|default|define|do|dynamicparam|else|elseif|end|exit|finally|for|foreach(?!-object)|from|if|in|inlinescript|parallel|param|process|return|switch|throw|trap|try|until|var|where(?!-object)|while)|%|\?)(?!\w)</string>
 			<key>name</key>
 			<string>keyword.control.powershell</string>
 		</dict>

--- a/spec/testfiles/syntax_test_TheBigTestFile.ps1
+++ b/spec/testfiles/syntax_test_TheBigTestFile.ps1
@@ -1110,6 +1110,10 @@ $b -cLike $c
 #                   ^ keyword.operator.string-format.powershell
 
 # Misc test cases
+New-Object -TypeName System.Diagnostics.Process
+#                                       ^ not:keyword.control.powershell
+New-Object -TypeName System.Data
+#                           ^ not:keyword.control.powershell
 @("any","array","has").foreach({ $_ })
 # <- keyword.other.array.begin.powershell
 # ^ meta.group.array-expression.powershell

--- a/spec/testfiles/syntax_test_TheBigTestFile.ps1
+++ b/spec/testfiles/syntax_test_TheBigTestFile.ps1
@@ -1110,6 +1110,8 @@ $b -cLike $c
 #                   ^ keyword.operator.string-format.powershell
 
 # Misc test cases
+Test-Function -Class ClassName
+#              ^ not:storage.type.powershell
 New-Object -TypeName System.Diagnostics.Process
 #                                       ^ not:keyword.control.powershell
 New-Object -TypeName System.Data


### PR DESCRIPTION
Fixes process keyword coloring when used as part of namespace (#47)

**Before:**

![image](https://user-images.githubusercontent.com/16168755/40535114-79fec61e-6008-11e8-9c31-784015b182f7.png)

**After:**

![image](https://user-images.githubusercontent.com/16168755/40535086-5fc6b27a-6008-11e8-8345-71a90e928a29.png)