### PR TITLE
Add sequence as a keyword

### DIFF
--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -242,7 +242,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>(?&lt;!\w|-|\.)((?i:begin|break|catch|continue|data|default|define|do|dynamicparam|else|elseif|end|exit|finally|for|from|if|in|inlinescript|parallel|param|process|return|switch|throw|trap|try|until|var|while)|%|\?)(?!\w)</string>
+			<string>(?&lt;!\w|-|\.)((?i:begin|break|catch|continue|data|default|define|do|dynamicparam|else|elseif|end|exit|finally|for|from|if|in|inlinescript|parallel|param|process|return|sequence|switch|throw|trap|try|until|var|while)|%|\?)(?!\w)</string>
 			<key>name</key>
 			<string>keyword.control.powershell</string>
 		</dict>

--- a/spec/testfiles/syntax_test_TheBigTestFile.ps1
+++ b/spec/testfiles/syntax_test_TheBigTestFile.ps1
@@ -1161,11 +1161,14 @@ workflow w1 {}
 #        ^ entity.name.function.powershell
 #           ^ punctuation.section.braces.begin.powershell
 #            ^ punctuation.section.braces.end.powershell
-Workflow work {}
+Workflow work { sequence {} }
 # <- storage.type.powershell
 #        ^ entity.name.function.powershell
 #             ^ punctuation.section.braces.begin.powershell
-#              ^ punctuation.section.braces.end.powershell
+#               ^^^^^^^^ keyword.control.powershell
+#                        ^ punctuation.section.braces.begin.powershell
+#                         ^ punctuation.section.braces.end.powershell
+#                           ^ punctuation.section.braces.end.powershell
 get-thing | Out-WithYou > $null # destroy
 # ^          ^ support.function.powershell
 #         ^ keyword.operator.other.powershell


### PR DESCRIPTION
Fix for https://github.com/SublimeText/PowerShell/issues/105

`sequence` is a keyword in the context of `workflow`, it's like a `process` block inside `function`.