### PR TITLE
Fix #116 and add support for SupportsPaging attribute

### DIFF
--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -474,7 +474,7 @@
 						</dict>
 						<dict>
 							<key>match</key>
-							<string>(?i)\b(mandatory|valuefrompipeline|valuefrompipelinebypropertyname|valuefromremainingarguments|position|parametersetname|defaultparametersetname|supportsshouldprocess|positionalbinding|helpuri|confirmimpact|helpmessage)\b(?:\s+)?(=)</string>
+							<string>(?i)\b(mandatory|valuefrompipeline|valuefrompipelinebypropertyname|valuefromremainingarguments|position|parametersetname|defaultparametersetname|supportsshouldprocess|supportspaging|positionalbinding|helpuri|confirmimpact|helpmessage)\b(?:\s+)?(=)?</string>
 							<key>captures</key>
 							<dict>
 								<key>1</key>

--- a/spec/testfiles/syntax_test_TheBigTestFile.ps1
+++ b/spec/testfiles/syntax_test_TheBigTestFile.ps1
@@ -791,6 +791,9 @@ function Verb-Noun
         #                  ^ meta.attribute.powershell keyword.operator.assignment.powershell
         #                   ^ meta.attribute.powershell constant.numeric.integer.powershell
         #                    ^ meta.attribute.powershell keyword.operator.other.powershell
+                   SupportsPaging,
+        #          ^^^^^^^^^^^^^^ meta.attribute.powershell variable.parameter.attribute.powershell
+        #                        ^ meta.attribute.powershell keyword.operator.other.powershell
                    ParameterSetName = 'Parameter Set 1')]
         #          ^^^^^^^^^^^^^^^^ meta.attribute.powershell variable.parameter.attribute.powershell
         #                           ^ meta.attribute.powershell keyword.operator.assignment.powershell


### PR DESCRIPTION
This fixes #116 and also adds support for [*SupportsPaging*](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_functions_cmdletbindingattribute?view=powershell-6) attribute.

![image](https://user-images.githubusercontent.com/16168755/41190835-f202cc08-6be5-11e8-93d9-65272aa6100e.png)


