### PR TITLE
Scopes

### DIFF
--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -253,10 +253,29 @@
 			<string>keyword.control.powershell</string>
 		</dict>
 		<dict>
-			<key>match</key>
+			<key>begin</key>
 			<string>(?&lt;!\w)(--%)(?!\w)</string>
-			<key>name</key>
-			<string>keyword.control.powershell</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.control.powershell</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>$</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>.+</string>
+					<key>name</key>
+					<string>string.unquoted.powershell</string>
+				</dict>
+			</array>
+			<key>comment</key>
+			<string>This should be moved to the repository at some point.</string>
 		</dict>
 		<dict>
 			<key>comment</key>

--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -996,15 +996,15 @@
 				<dict>
 					<key>captures</key>
 					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>constant.language.powershell</string>
+						</dict>
 						<key>1</key>
 						<dict>
 							<key>name</key>
 							<string>keyword.other.variable.definition.powershell</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>constant.language.powershell</string>
 						</dict>
 					</dict>
 					<key>comment</key>
@@ -1015,15 +1015,15 @@
 				<dict>
 					<key>captures</key>
 					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>support.constant.variable.powershell</string>
+						</dict>
 						<key>1</key>
 						<dict>
 							<key>name</key>
 							<string>keyword.other.variable.definition.powershell</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>support.constant.variable.powershell</string>
 						</dict>
 						<key>3</key>
 						<dict>
@@ -1039,15 +1039,15 @@
 				<dict>
 					<key>captures</key>
 					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>support.constant.automatic.powershell</string>
+						</dict>
 						<key>1</key>
 						<dict>
 							<key>name</key>
 							<string>keyword.other.variable.definition.powershell</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>support.constant.automatic.powershell</string>
 						</dict>
 						<key>3</key>
 						<dict>
@@ -1063,15 +1063,15 @@
 				<dict>
 					<key>captures</key>
 					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>variable.language.powershell</string>
+						</dict>
 						<key>1</key>
 						<dict>
 							<key>name</key>
 							<string>keyword.other.variable.definition.powershell</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>variable.language.powershell</string>
 						</dict>
 						<key>3</key>
 						<dict>
@@ -1087,6 +1087,11 @@
 				<dict>
 					<key>captures</key>
 					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>variable.other.readwrite.powershell</string>
+						</dict>
 						<key>1</key>
 						<dict>
 							<key>name</key>
@@ -1096,11 +1101,6 @@
 						<dict>
 							<key>name</key>
 							<string>storage.modifier.scope.powershell</string>
-						</dict>
-						<key>3</key>
-						<dict>
-							<key>name</key>
-							<string>variable.other.readwrite.powershell</string>
 						</dict>
 						<key>4</key>
 						<dict>
@@ -1114,6 +1114,11 @@
 				<dict>
 					<key>captures</key>
 					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>variable.other.readwrite.powershell</string>
+						</dict>
 						<key>1</key>
 						<dict>
 							<key>name</key>
@@ -1128,11 +1133,6 @@
 						<dict>
 							<key>name</key>
 							<string>storage.modifier.scope.powershell</string>
-						</dict>
-						<key>4</key>
-						<dict>
-							<key>name</key>
-							<string>variable.other.readwrite.powershell</string>
 						</dict>
 						<key>5</key>
 						<dict>
@@ -1151,6 +1151,11 @@
 				<dict>
 					<key>captures</key>
 					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>variable.other.readwrite.powershell</string>
+						</dict>
 						<key>1</key>
 						<dict>
 							<key>name</key>
@@ -1160,11 +1165,6 @@
 						<dict>
 							<key>name</key>
 							<string>support.variable.drive.powershell</string>
-						</dict>
-						<key>3</key>
-						<dict>
-							<key>name</key>
-							<string>variable.other.readwrite.powershell</string>
 						</dict>
 						<key>4</key>
 						<dict>
@@ -1178,6 +1178,11 @@
 				<dict>
 					<key>captures</key>
 					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>variable.other.readwrite.powershell</string>
+						</dict>
 						<key>1</key>
 						<dict>
 							<key>name</key>
@@ -1192,11 +1197,6 @@
 						<dict>
 							<key>name</key>
 							<string>support.variable.drive.powershell</string>
-						</dict>
-						<key>4</key>
-						<dict>
-							<key>name</key>
-							<string>variable.other.readwrite.powershell</string>
 						</dict>
 						<key>5</key>
 						<dict>
@@ -1280,15 +1280,15 @@
 				<dict>
 					<key>captures</key>
 					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>constant.language.powershell</string>
+						</dict>
 						<key>1</key>
 						<dict>
 							<key>name</key>
 							<string>keyword.other.variable.definition.powershell</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>constant.language.powershell</string>
 						</dict>
 					</dict>
 					<key>comment</key>
@@ -1299,15 +1299,15 @@
 				<dict>
 					<key>captures</key>
 					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>support.constant.variable.powershell</string>
+						</dict>
 						<key>1</key>
 						<dict>
 							<key>name</key>
 							<string>keyword.other.variable.definition.powershell</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>support.constant.variable.powershell</string>
 						</dict>
 						<key>3</key>
 						<dict>
@@ -1323,15 +1323,15 @@
 				<dict>
 					<key>captures</key>
 					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>support.variable.automatic.powershell</string>
+						</dict>
 						<key>1</key>
 						<dict>
 							<key>name</key>
 							<string>keyword.other.variable.definition.powershell</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>support.variable.automatic.powershell</string>
 						</dict>
 						<key>3</key>
 						<dict>
@@ -1347,15 +1347,15 @@
 				<dict>
 					<key>captures</key>
 					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>variable.language.powershell</string>
+						</dict>
 						<key>1</key>
 						<dict>
 							<key>name</key>
 							<string>keyword.other.variable.definition.powershell</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>variable.language.powershell</string>
 						</dict>
 						<key>3</key>
 						<dict>
@@ -1371,6 +1371,11 @@
 				<dict>
 					<key>captures</key>
 					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>variable.other.readwrite.powershell</string>
+						</dict>
 						<key>1</key>
 						<dict>
 							<key>name</key>
@@ -1380,11 +1385,6 @@
 						<dict>
 							<key>name</key>
 							<string>storage.modifier.scope.powershell</string>
-						</dict>
-						<key>3</key>
-						<dict>
-							<key>name</key>
-							<string>variable.other.readwrite.powershell</string>
 						</dict>
 						<key>4</key>
 						<dict>
@@ -1398,6 +1398,11 @@
 				<dict>
 					<key>captures</key>
 					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>variable.other.readwrite.powershell</string>
+						</dict>
 						<key>1</key>
 						<dict>
 							<key>name</key>
@@ -1407,11 +1412,6 @@
 						<dict>
 							<key>name</key>
 							<string>storage.modifier.scope.powershell</string>
-						</dict>
-						<key>3</key>
-						<dict>
-							<key>name</key>
-							<string>variable.other.readwrite.powershell</string>
 						</dict>
 						<key>4</key>
 						<dict>
@@ -1430,6 +1430,11 @@
 				<dict>
 					<key>captures</key>
 					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>variable.other.readwrite.powershell</string>
+						</dict>
 						<key>1</key>
 						<dict>
 							<key>name</key>
@@ -1439,11 +1444,6 @@
 						<dict>
 							<key>name</key>
 							<string>support.variable.drive.powershell</string>
-						</dict>
-						<key>3</key>
-						<dict>
-							<key>name</key>
-							<string>variable.other.readwrite.powershell</string>
 						</dict>
 						<key>4</key>
 						<dict>
@@ -1457,6 +1457,11 @@
 				<dict>
 					<key>captures</key>
 					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>variable.other.readwrite.powershell</string>
+						</dict>
 						<key>1</key>
 						<dict>
 							<key>name</key>
@@ -1471,11 +1476,6 @@
 						<dict>
 							<key>name</key>
 							<string>support.variable.drive.powershell</string>
-						</dict>
-						<key>4</key>
-						<dict>
-							<key>name</key>
-							<string>variable.other.readwrite.powershell</string>
 						</dict>
 						<key>5</key>
 						<dict>

--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -220,7 +220,7 @@
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>keyword.other.variable.definition.powershell</string>
+					<string>punctuation.definition.variable.powershell</string>
 				</dict>
 				<key>2</key>
 				<dict>
@@ -760,7 +760,7 @@
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>keyword.other.variable.definition.powershell</string>
+					<string>punctuation.definition.variable.powershell</string>
 				</dict>
 				<key>2</key>
 				<dict>
@@ -1004,7 +1004,7 @@
 						<key>1</key>
 						<dict>
 							<key>name</key>
-							<string>keyword.other.variable.definition.powershell</string>
+							<string>punctuation.definition.variable.powershell</string>
 						</dict>
 					</dict>
 					<key>comment</key>
@@ -1023,7 +1023,7 @@
 						<key>1</key>
 						<dict>
 							<key>name</key>
-							<string>keyword.other.variable.definition.powershell</string>
+							<string>punctuation.definition.variable.powershell</string>
 						</dict>
 						<key>3</key>
 						<dict>
@@ -1047,7 +1047,7 @@
 						<key>1</key>
 						<dict>
 							<key>name</key>
-							<string>keyword.other.variable.definition.powershell</string>
+							<string>punctuation.definition.variable.powershell</string>
 						</dict>
 						<key>3</key>
 						<dict>
@@ -1071,7 +1071,7 @@
 						<key>1</key>
 						<dict>
 							<key>name</key>
-							<string>keyword.other.variable.definition.powershell</string>
+							<string>punctuation.definition.variable.powershell</string>
 						</dict>
 						<key>3</key>
 						<dict>
@@ -1095,7 +1095,7 @@
 						<key>1</key>
 						<dict>
 							<key>name</key>
-							<string>keyword.other.variable.definition.powershell</string>
+							<string>punctuation.definition.variable.powershell</string>
 						</dict>
 						<key>2</key>
 						<dict>
@@ -1122,7 +1122,7 @@
 						<key>1</key>
 						<dict>
 							<key>name</key>
-							<string>keyword.other.variable.definition.powershell</string>
+							<string>punctuation.definition.variable.powershell</string>
 						</dict>
 						<key>2</key>
 						<dict>
@@ -1159,7 +1159,7 @@
 						<key>1</key>
 						<dict>
 							<key>name</key>
-							<string>keyword.other.variable.definition.powershell</string>
+							<string>punctuation.definition.variable.powershell</string>
 						</dict>
 						<key>2</key>
 						<dict>
@@ -1186,7 +1186,7 @@
 						<key>1</key>
 						<dict>
 							<key>name</key>
-							<string>keyword.other.variable.definition.powershell</string>
+							<string>punctuation.definition.variable.powershell</string>
 						</dict>
 						<key>2</key>
 						<dict>
@@ -1288,7 +1288,7 @@
 						<key>1</key>
 						<dict>
 							<key>name</key>
-							<string>keyword.other.variable.definition.powershell</string>
+							<string>punctuation.definition.variable.powershell</string>
 						</dict>
 					</dict>
 					<key>comment</key>
@@ -1307,7 +1307,7 @@
 						<key>1</key>
 						<dict>
 							<key>name</key>
-							<string>keyword.other.variable.definition.powershell</string>
+							<string>punctuation.definition.variable.powershell</string>
 						</dict>
 						<key>3</key>
 						<dict>
@@ -1331,7 +1331,7 @@
 						<key>1</key>
 						<dict>
 							<key>name</key>
-							<string>keyword.other.variable.definition.powershell</string>
+							<string>punctuation.definition.variable.powershell</string>
 						</dict>
 						<key>3</key>
 						<dict>
@@ -1355,7 +1355,7 @@
 						<key>1</key>
 						<dict>
 							<key>name</key>
-							<string>keyword.other.variable.definition.powershell</string>
+							<string>punctuation.definition.variable.powershell</string>
 						</dict>
 						<key>3</key>
 						<dict>
@@ -1379,7 +1379,7 @@
 						<key>1</key>
 						<dict>
 							<key>name</key>
-							<string>keyword.other.variable.definition.powershell</string>
+							<string>punctuation.definition.variable.powershell</string>
 						</dict>
 						<key>2</key>
 						<dict>
@@ -1406,7 +1406,7 @@
 						<key>1</key>
 						<dict>
 							<key>name</key>
-							<string>keyword.other.variable.definition.powershell</string>
+							<string>punctuation.definition.variable.powershell</string>
 						</dict>
 						<key>2</key>
 						<dict>
@@ -1438,7 +1438,7 @@
 						<key>1</key>
 						<dict>
 							<key>name</key>
-							<string>keyword.other.variable.definition.powershell</string>
+							<string>punctuation.definition.variable.powershell</string>
 						</dict>
 						<key>2</key>
 						<dict>
@@ -1465,7 +1465,7 @@
 						<key>1</key>
 						<dict>
 							<key>name</key>
-							<string>keyword.other.variable.definition.powershell</string>
+							<string>punctuation.definition.variable.powershell</string>
 						</dict>
 						<key>2</key>
 						<dict>

--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -102,8 +102,24 @@
 		<dict>
 			<key>begin</key>
 			<string>(?&lt;!')'</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.string.begin.powershell</string>
+				</dict>
+			</dict>
 			<key>end</key>
 			<string>'(?!')</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.string.end.powershell</string>
+				</dict>
+			</dict>
 			<key>name</key>
 			<string>string.quoted.single.powershell</string>
 			<key>patterns</key>
@@ -511,8 +527,24 @@
 						<dict>
 							<key>begin</key>
 							<string>(?&lt;!')'</string>
+							<key>beginCaptures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.definition.string.begin.powershell</string>
+								</dict>
+							</dict>
 							<key>end</key>
 							<string>'(?!')</string>
+							<key>endCaptures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.definition.string.end.powershell</string>
+								</dict>
+							</dict>
 							<key>name</key>
 							<string>string.quoted.single.powershell</string>
 							<key>patterns</key>
@@ -1530,8 +1562,24 @@
 		<dict>
 			<key>begin</key>
 			<string>(?&lt;!(?&lt;!`)")"</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.string.begin.powershell</string>
+				</dict>
+			</dict>
 			<key>end</key>
 			<string>"(?!")</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.string.end.powershell</string>
+				</dict>
+			</dict>
 			<key>name</key>
 			<string>string.quoted.double.powershell</string>
 			<key>patterns</key>

--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -1028,7 +1028,7 @@
 						<key>3</key>
 						<dict>
 							<key>name</key>
-							<string>entity.name.function.invocation.powershell</string>
+							<string>variable.other.member.powershell</string>
 						</dict>
 					</dict>
 					<key>comment</key>
@@ -1052,7 +1052,7 @@
 						<key>3</key>
 						<dict>
 							<key>name</key>
-							<string>entity.name.function.invocation.powershell</string>
+							<string>variable.other.member.powershell</string>
 						</dict>
 					</dict>
 					<key>comment</key>
@@ -1076,7 +1076,7 @@
 						<key>3</key>
 						<dict>
 							<key>name</key>
-							<string>entity.name.function.invocation.powershell</string>
+							<string>variable.other.member.powershell</string>
 						</dict>
 					</dict>
 					<key>comment</key>
@@ -1105,7 +1105,7 @@
 						<key>4</key>
 						<dict>
 							<key>name</key>
-							<string>entity.name.function.invocation.powershell</string>
+							<string>variable.other.member.powershell</string>
 						</dict>
 					</dict>
 					<key>match</key>
@@ -1142,7 +1142,7 @@
 						<key>6</key>
 						<dict>
 							<key>name</key>
-							<string>entity.name.function.invocation.powershell</string>
+							<string>variable.other.member.powershell</string>
 						</dict>
 					</dict>
 					<key>match</key>
@@ -1169,7 +1169,7 @@
 						<key>4</key>
 						<dict>
 							<key>name</key>
-							<string>entity.name.function.invocation.powershell</string>
+							<string>variable.other.member.powershell</string>
 						</dict>
 					</dict>
 					<key>match</key>
@@ -1206,7 +1206,7 @@
 						<key>6</key>
 						<dict>
 							<key>name</key>
-							<string>entity.name.function.invocation.powershell</string>
+							<string>variable.other.member.powershell</string>
 						</dict>
 					</dict>
 					<key>match</key>
@@ -1312,7 +1312,7 @@
 						<key>3</key>
 						<dict>
 							<key>name</key>
-							<string>entity.name.function.invocation.powershell</string>
+							<string>variable.other.member.powershell</string>
 						</dict>
 					</dict>
 					<key>comment</key>
@@ -1336,7 +1336,7 @@
 						<key>3</key>
 						<dict>
 							<key>name</key>
-							<string>entity.name.function.invocation.powershell</string>
+							<string>variable.other.member.powershell</string>
 						</dict>
 					</dict>
 					<key>comment</key>
@@ -1360,7 +1360,7 @@
 						<key>3</key>
 						<dict>
 							<key>name</key>
-							<string>entity.name.function.invocation.powershell</string>
+							<string>variable.other.member.powershell</string>
 						</dict>
 					</dict>
 					<key>comment</key>
@@ -1389,7 +1389,7 @@
 						<key>4</key>
 						<dict>
 							<key>name</key>
-							<string>entity.name.function.invocation.powershell</string>
+							<string>variable.other.member.powershell</string>
 						</dict>
 					</dict>
 					<key>match</key>
@@ -1421,7 +1421,7 @@
 						<key>5</key>
 						<dict>
 							<key>name</key>
-							<string>entity.name.function.invocation.powershell</string>
+							<string>variable.other.member.powershell</string>
 						</dict>
 					</dict>
 					<key>match</key>
@@ -1448,7 +1448,7 @@
 						<key>4</key>
 						<dict>
 							<key>name</key>
-							<string>entity.name.function.invocation.powershell</string>
+							<string>variable.other.member.powershell</string>
 						</dict>
 					</dict>
 					<key>match</key>

--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -331,7 +331,7 @@
 			<key>match</key>
 			<string>\|{2}|&amp;{2}|;</string>
 			<key>name</key>
-			<string>keyword.other.statement-separator.powershell</string>
+			<string>punctuation.terminator.statement.powershell</string>
 		</dict>
 		<dict>
 			<key>match</key>

--- a/spec/testfiles/syntax_test_Class.ps1
+++ b/spec/testfiles/syntax_test_Class.ps1
@@ -64,7 +64,7 @@ class TypeName
         $this.P1 = $s
         # <- keyword.other.variable.definition.powershell
         # ^ support.constant.automatic.powershell
-        #     ^^ entity.name.function.invocation.powershell
+        #     ^^ variable.other.member.powershell
         #        ^ keyword.operator.assignment.powershell
         #          ^ keyword.other.variable.definition.powershell
         #           ^ variable.other.readwrite.powershell
@@ -111,7 +111,7 @@ class TypeName
         $this.P3 = $i
         # <- keyword.other.variable.definition.powershell
         # ^ support.constant.automatic.powershell
-        #     ^^ entity.name.function.invocation.powershell
+        #     ^^ variable.other.member.powershell
         #        ^ keyword.operator.assignment.powershell
         #          ^ keyword.other.variable.definition.powershell
         #           ^ variable.other.readwrite.powershell
@@ -119,6 +119,6 @@ class TypeName
         # <- keyword.control.powershell
         #      ^ keyword.other.variable.definition.powershell
         #       ^^^^ support.constant.automatic.powershell
-        #            ^^ entity.name.function.invocation.powershell
+        #            ^^ variable.other.member.powershell
     }
 }

--- a/spec/testfiles/syntax_test_Class.ps1
+++ b/spec/testfiles/syntax_test_Class.ps1
@@ -25,7 +25,7 @@ class TypeName
     # <- punctuation.section.bracket.begin.powershell
     # ^ storage.type.powershell
     #      ^ punctuation.section.bracket.end.powershell
-    #        ^ keyword.other.variable.definition.powershell
+    #        ^ punctuation.definition.variable.powershell
     #         ^^ variable.other.readwrite.powershell
 
     # Static property
@@ -36,7 +36,7 @@ class TypeName
     #      ^ punctuation.section.bracket.begin.powershell
     #       ^ storage.type.powershell
     #                ^ punctuation.section.bracket.end.powershell
-    #                  ^ keyword.other.variable.definition.powershell
+    #                  ^ punctuation.definition.variable.powershell
     #                   ^^ variable.other.readwrite.powershell
 
     # Hidden property does not show as result of Get-Member
@@ -47,7 +47,7 @@ class TypeName
     #      ^ punctuation.section.bracket.begin.powershell
     #       ^ storage.type.powershell
     #          ^ punctuation.section.bracket.end.powershell
-    #            ^ keyword.other.variable.definition.powershell
+    #            ^ punctuation.definition.variable.powershell
     #             ^^ variable.other.readwrite.powershell
 
     # Constructor
@@ -58,15 +58,15 @@ class TypeName
         #     ^ punctuation.section.bracket.begin.powershell
         #      ^^^^^^ storage.type.powershell
         #            ^ punctuation.section.bracket.end.powershell
-        #              ^ keyword.other.variable.definition.powershell
+        #              ^ punctuation.definition.variable.powershell
         #               ^ variable.other.readwrite.powershell
         #                ^ punctuation.section.group.end.powershell
         $this.P1 = $s
-        # <- keyword.other.variable.definition.powershell
+        # <- punctuation.definition.variable.powershell
         # ^ support.constant.automatic.powershell
         #     ^^ variable.other.member.powershell
         #        ^ keyword.operator.assignment.powershell
-        #          ^ keyword.other.variable.definition.powershell
+        #          ^ punctuation.definition.variable.powershell
         #           ^ variable.other.readwrite.powershell
     }
 
@@ -82,7 +82,7 @@ class TypeName
     #                           ^ punctuation.section.bracket.begin.powershell
     #                            ^^^^^^^^^ storage.type.powershell
     #                                     ^ punctuation.section.bracket.end.powershell
-    #                                       ^ keyword.other.variable.definition.powershell
+    #                                       ^ punctuation.definition.variable.powershell
     #                                        ^ variable.other.readwrite.powershell
     #                                         ^ punctuation.section.group.end.powershell
         [TypeName]::P2 = $h
@@ -90,7 +90,7 @@ class TypeName
         # ^ storage.type.powershell
         #        ^ punctuation.section.bracket.end.powershell
         #              ^ keyword.operator.assignment.powershell
-        #                ^ keyword.other.variable.definition.powershell
+        #                ^ punctuation.definition.variable.powershell
         #                 ^ variable.other.readwrite.powershell
     }
 
@@ -105,19 +105,19 @@ class TypeName
     #                   ^ punctuation.section.bracket.begin.powershell
     #                    ^^^ storage.type.powershell
     #                       ^ punctuation.section.bracket.end.powershell
-    #                         ^ keyword.other.variable.definition.powershell
+    #                         ^ punctuation.definition.variable.powershell
     #                          ^ variable.other.readwrite.powershell
     #                           ^ punctuation.section.group.end.powershell
         $this.P3 = $i
-        # <- keyword.other.variable.definition.powershell
+        # <- punctuation.definition.variable.powershell
         # ^ support.constant.automatic.powershell
         #     ^^ variable.other.member.powershell
         #        ^ keyword.operator.assignment.powershell
-        #          ^ keyword.other.variable.definition.powershell
+        #          ^ punctuation.definition.variable.powershell
         #           ^ variable.other.readwrite.powershell
         return $this.P3
         # <- keyword.control.powershell
-        #      ^ keyword.other.variable.definition.powershell
+        #      ^ punctuation.definition.variable.powershell
         #       ^^^^ support.constant.automatic.powershell
         #            ^^ variable.other.member.powershell
     }

--- a/spec/testfiles/syntax_test_Function.ps1
+++ b/spec/testfiles/syntax_test_Function.ps1
@@ -61,12 +61,12 @@ function Verb-Noun {
                    SupportsShouldProcess    = $true,
                 #  ^^^^^^^^^^^^^^^^^^^^^ meta.attribute.powershell variable.parameter.attribute.powershell
                 #                           ^ meta.attribute.powershell keyword.operator.assignment.powershell
-                #                             ^ meta.attribute.powershell keyword.other.variable.definition.powershell
+                #                             ^ meta.attribute.powershell punctuation.definition.variable.powershell
                 #                              ^^^^ meta.attribute.powershell constant.language.powershell
                    PositionalBinding        = $false,
                 #  ^^^^^^^^^^^^^^^^^ meta.attribute.powershell variable.parameter.attribute.powershell
                 #                           ^ meta.attribute.powershell keyword.operator.assignment.powershell
-                #                             ^ meta.attribute.powershell keyword.other.variable.definition.powershell
+                #                             ^ meta.attribute.powershell punctuation.definition.variable.powershell
                 #                              ^^^^^ meta.attribute.powershell constant.language.powershell
                    HelpUri                  = 'http://www.microsoft.com/',
                 #  ^^^^^^^ meta.attribute.powershell variable.parameter.attribute.powershell
@@ -106,25 +106,25 @@ function Verb-Noun {
         #         ^ meta.attribute.powershell punctuation.section.group.begin.powershell
         #          ^^^^^^^^^ meta.attribute.powershell variable.parameter.attribute.powershell
         #                   ^ meta.attribute.powershell keyword.operator.assignment.powershell
-        #                    ^ meta.attribute.powershell keyword.other.variable.definition.powershell
+        #                    ^ meta.attribute.powershell punctuation.definition.variable.powershell
         #                     ^^^^ meta.attribute.powershell constant.language.powershell
         #                         ^ meta.attribute.powershell keyword.operator.other.powershell
                    ValueFromPipeline=$true,
         #          ^^^^^^^^^^^^^^^^^ meta.attribute.powershell variable.parameter.attribute.powershell
         #                           ^ meta.attribute.powershell keyword.operator.assignment.powershell
-        #                            ^ meta.attribute.powershell keyword.other.variable.definition.powershell
+        #                            ^ meta.attribute.powershell punctuation.definition.variable.powershell
         #                             ^^^^ meta.attribute.powershell constant.language.powershell
         #                                 ^ meta.attribute.powershell keyword.operator.other.powershell
                    ValueFromPipelineByPropertyName = $true,
         #          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute.powershell variable.parameter.attribute.powershell
         #                                          ^ meta.attribute.powershell keyword.operator.assignment.powershell
-        #                                            ^ meta.attribute.powershell keyword.other.variable.definition.powershell
+        #                                            ^ meta.attribute.powershell punctuation.definition.variable.powershell
         #                                             ^^^^ meta.attribute.powershell constant.language.powershell
         #                                                 ^ meta.attribute.powershell keyword.operator.other.powershell
                    ValueFromRemainingArguments=$false,
         #          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute.powershell variable.parameter.attribute.powershell
         #                                     ^ meta.attribute.powershell keyword.operator.assignment.powershell
-        #                                      ^ meta.attribute.powershell keyword.other.variable.definition.powershell
+        #                                      ^ meta.attribute.powershell punctuation.definition.variable.powershell
         #                                       ^^^^^ meta.attribute.powershell constant.language.powershell
         #                                            ^ meta.attribute.powershell keyword.operator.other.powershell
                    Position=0,
@@ -184,7 +184,7 @@ function Verb-Noun {
         #          ^ meta.attribute.powershell punctuation.section.group.end.powershell
         #           ^ meta.attribute.powershell punctuation.section.bracket.end.powershell
         $Param1,
-        # <- keyword.other.variable.definition.powershell
+        # <- punctuation.definition.variable.powershell
         # ^ variable.other.readwrite.powershell
         #      ^ keyword.operator.other.powershell
 
@@ -223,7 +223,7 @@ function Verb-Noun {
         # ^ meta.attribute.powershell support.function.attribute.powershell
         #              ^ meta.attribute.powershell punctuation.section.group.begin.powershell
         #               ^ meta.scriptblock.powershell meta.attribute.powershell
-        #                ^ meta.attribute.powershell keyword.other.variable.definition.powershell
+        #                ^ meta.attribute.powershell punctuation.definition.variable.powershell
         #                 ^^^^ meta.scriptblock.powershell constant.language.powershell
         #                     ^ meta.scriptblock.powershell meta.attribute.powershell
         #                      ^ meta.attribute.powershell punctuation.section.group.end.powershell
@@ -242,7 +242,7 @@ function Verb-Noun {
         # ^ storage.type.powershell
         #     ^ punctuation.section.bracket.end.powershell
         $Param2,
-        # <- keyword.other.variable.definition.powershell
+        # <- punctuation.definition.variable.powershell
         # ^ variable.other.readwrite.powershell
         #      ^ keyword.operator.other.powershell
 
@@ -279,7 +279,7 @@ function Verb-Noun {
         # ^ storage.type.powershell
         #      ^ punctuation.section.bracket.end.powershell
         $Param3,
-        # <- keyword.other.variable.definition.powershell
+        # <- punctuation.definition.variable.powershell
         # ^ variable.other.readwrite.powershell
         #      ^ keyword.operator.other.powershell
 
@@ -301,7 +301,7 @@ function Verb-Noun {
         #              ^ meta.attribute.powershell punctuation.section.group.begin.powershell
         #               ^ meta.attribute.powershell meta.scriptblock.powershell
         #                ^^^^^^^^^ meta.scriptblock.powershell support.function.powershell
-        #                          ^ meta.scriptblock.powershell keyword.other.variable.definition.powershell
+        #                          ^ meta.scriptblock.powershell punctuation.definition.variable.powershell
         #                           ^ meta.scriptblock.powershell support.constant.automatic.powershell
         #                            ^ meta.attribute.powershell meta.scriptblock.powershell
         #                             ^ meta.attribute.powershell punctuation.section.group.end.powershell
@@ -311,7 +311,7 @@ function Verb-Noun {
         # ^ storage.type.powershell
         #      ^ punctuation.section.bracket.end.powershell
         $Param4,
-        # <- keyword.other.variable.definition.powershell
+        # <- punctuation.definition.variable.powershell
         # ^ variable.other.readwrite.powershell
         #      ^ keyword.operator.other.powershell
 
@@ -341,7 +341,7 @@ function Verb-Noun {
         # ^ storage.type.powershell
         #      ^ punctuation.section.bracket.end.powershell
         $Param5
-        # <- keyword.other.variable.definition.powershell
+        # <- punctuation.definition.variable.powershell
         # ^ variable.other.readwrite.powershell
         )
         # <- punctuation.section.group.end.powershell
@@ -355,7 +355,7 @@ function Verb-Noun {
         if ($pscmdlet.ShouldProcess("Target", "Operation")) {
         # <- keyword.control.powershell
         #  ^ punctuation.section.group.begin.powershell
-        #   ^ keyword.other.variable.definition.powershell
+        #   ^ punctuation.definition.variable.powershell
         #    ^^^^^^^^ support.constant.automatic.powershell
         #             ^^^^^^^^^^^^^ variable.other.member.powershell
         #                          ^ punctuation.section.group.begin.powershell

--- a/spec/testfiles/syntax_test_Function.ps1
+++ b/spec/testfiles/syntax_test_Function.ps1
@@ -357,7 +357,7 @@ function Verb-Noun {
         #  ^ punctuation.section.group.begin.powershell
         #   ^ keyword.other.variable.definition.powershell
         #    ^^^^^^^^ support.constant.automatic.powershell
-        #             ^^^^^^^^^^^^^ entity.name.function.invocation.powershell
+        #             ^^^^^^^^^^^^^ variable.other.member.powershell
         #                          ^ punctuation.section.group.begin.powershell
         #                                                ^ punctuation.section.group.end.powershell
         #                                                 ^ punctuation.section.group.end.powershell

--- a/spec/testfiles/syntax_test_TheBigTestFile.ps1
+++ b/spec/testfiles/syntax_test_TheBigTestFile.ps1
@@ -133,7 +133,7 @@ ${script:variable}
 $variable.Name
 # <- keyword.other.variable.definition.powershell variable.other.readwrite.powershell
 # ^ variable.other.readwrite.powershell
-#        ^^^^^ entity.name.function.invocation.powershell
+#         ^^^^ variable.other.member.powershell
 
 # In double-quoted strings, only the variable should be highlighted, not the property
 "This is my $variable.Name!"
@@ -151,7 +151,7 @@ $variable.Name
 #            ^ punctuation.section.group.begin.powershell
 #                           ^ punctuation.section.group.end.powershell
 #              ^^^^^^^^ variable.other.readwrite.powershell
-#                       ^^^^ entity.name.function.invocation.powershell
+#                       ^^^^ variable.other.member.powershell
 #                             ^ punctuation.definition.string.end.powershell
 
 # $ENV:ComputerName should be highlighted
@@ -904,7 +904,7 @@ class Vehicle {
         $this.Mileage += $NumberOfMiles
 #       ^ keyword.other.variable.definition.powershell
 #        ^^^^ support.constant.automatic.powershell
-#             ^ entity.name.function.invocation.powershell
+#             ^ variable.other.member.powershell
 #                     ^^ keyword.operator.assignment.powershell
 
     }

--- a/spec/testfiles/syntax_test_TheBigTestFile.ps1
+++ b/spec/testfiles/syntax_test_TheBigTestFile.ps1
@@ -137,38 +137,47 @@ $variable.Name
 
 # In double-quoted strings, only the variable should be highlighted, not the property
 "This is my $variable.Name!"
-# <- string.quoted.double.powershell
+# <- punctuation.definition.string.begin.powershell string.quoted.double.powershell
 # ^^^^^^^^^^         ^^^^^^^ string.quoted.double.powershell
 #           ^ keyword.other.variable.definition.powershell
 #            ^^^^^^^^ variable.other.readwrite.powershell
+#                          ^ punctuation.definition.string.end.powershell
 
 # When used in a subexpression, both should be highlighted
 "This is my $($variable.Name)!"
-# <- string.quoted.double.powershell
+# <- punctuation.definition.string.begin.powershell string.quoted.double.powershell
 # ^^^^^^^^^^                 ^^ string.quoted.double.powershell
 #           ^ ^ keyword.other.variable.definition.powershell
 #            ^ punctuation.section.group.begin.powershell
 #                           ^ punctuation.section.group.end.powershell
 #              ^^^^^^^^ variable.other.readwrite.powershell
 #                       ^^^^ entity.name.function.invocation.powershell
+#                             ^ punctuation.definition.string.end.powershell
 
 # $ENV:ComputerName should be highlighted
 "This is the name of my computer: $ENV:ComputerName"
-# <- string.quoted.double.powershell
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                 ^ string.quoted.double.powershell
+# <- punctuation.definition.string.begin.powershell string.quoted.double.powershell
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double.powershell
 #                                 ^ keyword.other.variable.definition.powershell
 #                                  ^^^^ support.variable.drive.powershell
 #                                      ^^^^^^^^^^^^ variable.other.readwrite.powershell
+#                                                  ^ punctuation.definition.string.end.powershell
 
 # Here as well
 "This is the name of my computer: ${ENV:ComputerName}"
-# <- string.quoted.double.powershell
+# <- punctuation.definition.string.begin.powershell string.quoted.double.powershell
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                   ^ string.quoted.double.powershell
 #                                 ^ keyword.other.variable.definition.powershell
 #                                  ^ punctuation.section.braces.begin.powershell
 #                                   ^^^^ support.variable.drive.powershell
 #                                       ^^^^^^^^^^^^ variable.other.readwrite.powershell
-#                                                   ^ punctuation.section.braces.end.powershell
+#                                                    ^ punctuation.definition.string.end.powershell
+
+# Single quotes string
+'This is a string'
+# <- punctuation.definition.string.begin.powershell string.quoted.single.powershell
+# ^^^^^^^^^^^^^^^ string.quoted.single.powershell
+#                ^ punctuation.definition.string.end.powershell
 
 # Hashtable
 $properties = @{

--- a/spec/testfiles/syntax_test_TheBigTestFile.ps1
+++ b/spec/testfiles/syntax_test_TheBigTestFile.ps1
@@ -90,40 +90,40 @@ throw "Do not run this file!"
 
 # Automatic variables
 $_
-# <- keyword.other.variable.definition.powershell
+# <- punctuation.definition.variable.powershell
  # <- support.constant.automatic.powershell
 $args
-# <- keyword.other.variable.definition.powershell
+# <- punctuation.definition.variable.powershell
 # ^ support.constant.automatic.powershell
 $error
-# <- keyword.other.variable.definition.powershell
+# <- punctuation.definition.variable.powershell
 # ^ support.constant.variable.powershell
 $home
-# <- keyword.other.variable.definition.powershell
+# <- punctuation.definition.variable.powershell
 # ^ support.constant.variable.powershell
 $foreach
-# <- keyword.other.variable.definition.powershell
+# <- punctuation.definition.variable.powershell
 # ^ support.constant.automatic.powershell
 
 # Normal variables
 $variable
-# <- keyword.other.variable.definition.powershell
+# <- punctuation.definition.variable.powershell
 # ^ variable.other.readwrite.powershell
 $script:variable
-# <- keyword.other.variable.definition.powershell variable.other.readwrite.powershell
+# <- punctuation.definition.variable.powershell variable.other.readwrite.powershell
 # ^ storage.modifier.scope.powershell
 #       ^ variable.other.readwrite.powershell
 $ENV:ComputerName
-# <- keyword.other.variable.definition.powershell variable.other.readwrite.powershell
+# <- punctuation.definition.variable.powershell variable.other.readwrite.powershell
 # ^ support.variable.drive.powershell
 #    ^ variable.other.readwrite.powershell
 ${variable}
-# <- keyword.other.variable.definition.powershell variable.other.readwrite.powershell
+# <- punctuation.definition.variable.powershell variable.other.readwrite.powershell
  # <- punctuation.section.braces.begin.powershell
 # ^^^^^^^^ variable.other.readwrite.powershell
 #         ^ punctuation.section.braces.end.powershell
 ${script:variable}
-# <- keyword.other.variable.definition.powershell variable.other.readwrite.powershell
+# <- punctuation.definition.variable.powershell variable.other.readwrite.powershell
  # <- punctuation.section.braces.begin.powershell
 # ^ storage.modifier.scope.powershell
 #        ^ variable.other.readwrite.powershell
@@ -131,7 +131,7 @@ ${script:variable}
 
 # Variable properties should be highlighted
 $variable.Name
-# <- keyword.other.variable.definition.powershell variable.other.readwrite.powershell
+# <- punctuation.definition.variable.powershell variable.other.readwrite.powershell
 # ^ variable.other.readwrite.powershell
 #         ^^^^ variable.other.member.powershell
 
@@ -139,7 +139,7 @@ $variable.Name
 "This is my $variable.Name!"
 # <- punctuation.definition.string.begin.powershell string.quoted.double.powershell
 # ^^^^^^^^^^         ^^^^^^^ string.quoted.double.powershell
-#           ^ keyword.other.variable.definition.powershell
+#           ^ punctuation.definition.variable.powershell
 #            ^^^^^^^^ variable.other.readwrite.powershell
 #                          ^ punctuation.definition.string.end.powershell
 
@@ -147,7 +147,7 @@ $variable.Name
 "This is my $($variable.Name)!"
 # <- punctuation.definition.string.begin.powershell string.quoted.double.powershell
 # ^^^^^^^^^^                 ^^ string.quoted.double.powershell
-#           ^ ^ keyword.other.variable.definition.powershell
+#           ^ ^ punctuation.definition.variable.powershell
 #            ^ punctuation.section.group.begin.powershell
 #                           ^ punctuation.section.group.end.powershell
 #              ^^^^^^^^ variable.other.readwrite.powershell
@@ -158,7 +158,7 @@ $variable.Name
 "This is the name of my computer: $ENV:ComputerName"
 # <- punctuation.definition.string.begin.powershell string.quoted.double.powershell
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double.powershell
-#                                 ^ keyword.other.variable.definition.powershell
+#                                 ^ punctuation.definition.variable.powershell
 #                                  ^^^^ support.variable.drive.powershell
 #                                      ^^^^^^^^^^^^ variable.other.readwrite.powershell
 #                                                  ^ punctuation.definition.string.end.powershell
@@ -167,7 +167,7 @@ $variable.Name
 "This is the name of my computer: ${ENV:ComputerName}"
 # <- punctuation.definition.string.begin.powershell string.quoted.double.powershell
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                   ^ string.quoted.double.powershell
-#                                 ^ keyword.other.variable.definition.powershell
+#                                 ^ punctuation.definition.variable.powershell
 #                                  ^ punctuation.section.braces.begin.powershell
 #                                   ^^^^ support.variable.drive.powershell
 #                                       ^^^^^^^^^^^^ variable.other.readwrite.powershell
@@ -181,7 +181,7 @@ $variable.Name
 
 # Hashtable
 $properties = @{
-# <- keyword.other.variable.definition.powershell
+# <- punctuation.definition.variable.powershell
 # ^ variable.other.readwrite.powershell
 #           ^ keyword.operator.assignment.powershell
 #             ^ keyword.other.hashtable.begin.powershell
@@ -218,39 +218,39 @@ $properties = @{
 # Spatting
     Invoke-Something @properties
 #   ^^^^^^^^^^^^^^^^ support.function.powershell
-#                    ^ keyword.other.variable.definition.powershell
+#                    ^ punctuation.definition.variable.powershell
 #                     ^ variable.other.readwrite.powershell
 
 # ScriptBlock
     {Invoke-Something @properties}
 #   ^ punctuation.section.braces.begin.powershell
 #    ^^^^^^^^^^^^^^^^ support.function.powershell
-#                     ^ keyword.other.variable.definition.powershell
+#                     ^ punctuation.definition.variable.powershell
 #                      ^ variable.other.readwrite.powershell
 #                                ^ punctuation.section.braces.end.powershell
 {
 # <- punctuation.section.braces.begin.powershell
     Invoke-Something @properties
 #   ^^^^^^^^^^^^^^^^ support.function.powershell
-#                    ^ keyword.other.variable.definition.powershell
+#                    ^ punctuation.definition.variable.powershell
 #                     ^ variable.other.readwrite.powershell
 }
 # <- punctuation.section.braces.end.powershell
 $sb = {
-# <- keyword.other.variable.definition.powershell
+# <- punctuation.definition.variable.powershell
 # ^ variable.other.readwrite.powershell
 #   ^ keyword.operator.assignment.powershell
 #     ^ punctuation.section.braces.begin.powershell
     Invoke-Something @properties
 #   ^^^^^^^^^^^^^^^^ support.function.powershell
-#                    ^ keyword.other.variable.definition.powershell
+#                    ^ punctuation.definition.variable.powershell
 #                     ^ variable.other.readwrite.powershell
 }
 # <- punctuation.section.braces.end.powershell
 
 # Arrays
 $a1 = @(1,2,3,4)
-# <- keyword.other.variable.definition.powershell variable.other.readwrite.powershell
+# <- punctuation.definition.variable.powershell variable.other.readwrite.powershell
 # ^ variable.other.readwrite.powershell
 #   ^ keyword.operator.assignment.powershell
 #     ^ keyword.other.array.begin.powershell
@@ -259,7 +259,7 @@ $a1 = @(1,2,3,4)
 #       ^ ^ ^ ^ meta.group.array-expression.powershell constant.numeric.integer.powershell
 #        ^ ^ ^ meta.group.array-expression.powershell keyword.operator.other.powershell
 $a2 = ('one','two','three','four')
-# <- keyword.other.variable.definition.powershell variable.other.readwrite.powershell
+# <- punctuation.definition.variable.powershell variable.other.readwrite.powershell
 # ^ variable.other.readwrite.powershell
 #   ^ keyword.operator.assignment.powershell
 #     ^ punctuation.section.group.begin.powershell
@@ -267,25 +267,25 @@ $a2 = ('one','two','three','four')
 #           ^     ^       ^ keyword.operator.other.powershell
 #                                ^ punctuation.section.group.end.powershell
 $a3 = $one, $two, $three, $four
-# <- keyword.other.variable.definition.powershell variable.other.readwrite.powershell
-#     ^     ^     ^       ^ keyword.other.variable.definition.powershell
+# <- punctuation.definition.variable.powershell variable.other.readwrite.powershell
+#     ^     ^     ^       ^ punctuation.definition.variable.powershell
 # ^    ^     ^     ^       ^ variable.other.readwrite.powershell
 #   ^ keyword.operator.assignment.powershell
 #         ^     ^       ^ keyword.operator.other.powershell
 $a1[0]
-# <- keyword.other.variable.definition.powershell variable.other.readwrite.powershell
+# <- punctuation.definition.variable.powershell variable.other.readwrite.powershell
 # ^ variable.other.readwrite.powershell
 #  ^ punctuation.section.bracket.begin.powershell
 #   ^ constant.numeric.integer.powershell
 #    ^ punctuation.section.bracket.end.powershell
 $a2[-1]
-# <- keyword.other.variable.definition.powershell variable.other.readwrite.powershell
+# <- punctuation.definition.variable.powershell variable.other.readwrite.powershell
 # ^ variable.other.readwrite.powershell
 #  ^ punctuation.section.bracket.begin.powershell
 #   ^^ constant.numeric.integer.powershell
 #     ^ punctuation.section.bracket.end.powershell
 $a3[1..2]
-# <- keyword.other.variable.definition.powershell variable.other.readwrite.powershell
+# <- punctuation.definition.variable.powershell variable.other.readwrite.powershell
 # ^ variable.other.readwrite.powershell
 #  ^ punctuation.section.bracket.begin.powershell
 #   ^  ^ constant.numeric.integer.powershell
@@ -294,13 +294,13 @@ $a3[1..2]
     @(@($a))
 #   ^ ^ keyword.other.array.begin.powershell
 #    ^ ^ punctuation.section.group.begin.powershell
-#       ^ keyword.other.variable.definition.powershell variable.other.readwrite.powershell
+#       ^ punctuation.definition.variable.powershell variable.other.readwrite.powershell
 #        ^ variable.other.readwrite.powershell
 #         ^^ punctuation.section.group.end.powershell
     @(($i = 10); (++$j))
 #   ^ keyword.other.array.begin.powershell
 #    ^^          ^ punctuation.section.group.begin.powershell
-#      ^            ^ keyword.other.variable.definition.powershell variable.other.readwrite.powershell
+#      ^            ^ punctuation.definition.variable.powershell variable.other.readwrite.powershell
 #       ^            ^ variable.other.readwrite.powershell
 #         ^ keyword.operator.assignment.powershell
 #           ^^ constant.numeric.integer.powershell
@@ -310,13 +310,13 @@ $a3[1..2]
     @($i = 10)
 #   ^ keyword.other.array.begin.powershell
 #    ^ punctuation.section.group.begin.powershell
-#     ^ keyword.other.variable.definition.powershell variable.other.readwrite.powershell
+#     ^ punctuation.definition.variable.powershell variable.other.readwrite.powershell
 #      ^ variable.other.readwrite.powershell
 #        ^ keyword.operator.assignment.powershell
 #          ^^ constant.numeric.integer.powershell
 #            ^ punctuation.section.group.end.powershell
     $i[($y - 1) + $x]
-#   ^   ^         ^ keyword.other.variable.definition.powershell variable.other.readwrite.powershell
+#   ^   ^         ^ punctuation.definition.variable.powershell variable.other.readwrite.powershell
 #    ^   ^         ^ variable.other.readwrite.powershell
 #     ^ punctuation.section.bracket.begin.powershell
 #      ^ punctuation.section.group.begin.powershell
@@ -345,7 +345,7 @@ $a3[1..2]
 #   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double.powershell
     "$This is a double ""quoted"" string."
 #   ^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double.powershell
-#    ^ keyword.other.variable.definition.powershell support.variable.automatic.powershell
+#    ^ punctuation.definition.variable.powershell support.variable.automatic.powershell
 #     ^^^^ support.variable.automatic.powershell
     "This is a
     double quoted string."
@@ -354,7 +354,7 @@ $a3[1..2]
 #   ^^^^^^^^^^^^ string.quoted.double.powershell
     "$(Invoke-Something)"
 #   ^                   ^ string.quoted.double.powershell
-#    ^ keyword.other.variable.definition.powershell
+#    ^ punctuation.definition.variable.powershell
 #     ^ punctuation.section.group.begin.powershell
 #      ^ interpolated.complex.source.powershell support.function.powershell
 #                      ^ punctuation.section.group.end.powershell
@@ -366,7 +366,7 @@ $a3[1..2]
 # <- string.quoted.double.heredoc.powershell
  # <- string.quoted.double.heredoc.powershell
 $This is a 'double quoted'
-# <- keyword.other.variable.definition.powershell
+# <- punctuation.definition.variable.powershell
 # ^ string.quoted.double.heredoc.powershell support.variable.automatic.powershell
 Isn't it "nice"??
 "@
@@ -421,7 +421,7 @@ Isn't it "nice"??
     -10.002L
 #   ^^^^^^^^ constant.numeric.integer.powershell
     $x..5.40D
-#   ^ keyword.other.variable.definition.powershell
+#   ^ punctuation.definition.variable.powershell
 #    ^ variable.other.readwrite.powershell
 #     ^^ keyword.operator.range.powershell
 #       ^^^^^ constant.numeric.integer.powershell
@@ -429,14 +429,14 @@ Isn't it "nice"??
 #   ^^^^  ^^^^ constant.numeric.integer.powershell
 #       ^^ keyword.operator.range.powershell
     $true..3
-#   ^ keyword.other.variable.definition.powershell
+#   ^ punctuation.definition.variable.powershell
 #    ^^^^ constant.language.powershell
 #        ^^ keyword.operator.range.powershell
 #          ^ constant.numeric.integer.powershell
     -2..$null
 #   ^^ constant.numeric.integer.powershell
 #     ^^ keyword.operator.range.powershell
-#       ^ keyword.other.variable.definition.powershell constant.language.powershell
+#       ^ punctuation.definition.variable.powershell constant.language.powershell
 #        ^^^^ constant.language.powershell
     -3..3
 #   ^^  ^ constant.numeric.integer.powershell
@@ -499,7 +499,7 @@ Invoke-Something -foobar value
 Invoke-Something -foobar:$true
 # <- support.function.powershell
 #                ^ keyword.operator.assignment.powershell
-#                        ^ keyword.other.variable.definition.powershell
+#                        ^ punctuation.definition.variable.powershell
 #                         ^^^^ constant.language.powershell
 Invoke-Something -foobar: $true
 # <- support.function.powershell
@@ -525,7 +525,7 @@ Invoke-Something -p1 {
     Invoke-Something -foobar:$true
 #   ^ support.function.powershell
 #                    ^ keyword.operator.assignment.powershell
-#                            ^ keyword.other.variable.definition.powershell
+#                            ^ punctuation.definition.variable.powershell
 #                             ^^^^ constant.language.powershell
 } | Invoke-Something
 # <- punctuation.section.braces.end.powershell
@@ -541,7 +541,7 @@ Invoke-Something -p1 value `
 #            ^ keyword.operator.other.powershell
     -p3 $value | Invoke-Something -verbose
 #   ^                             ^ keyword.operator.assignment.powershell
-#       ^ keyword.other.variable.definition.powershell
+#       ^ punctuation.definition.variable.powershell
 #              ^ keyword.operator.other.powershell
 #                ^^^^^^^^^^^^^^^^ support.function.powershell
 
@@ -589,7 +589,7 @@ switch -Wildcard ($a) {}
 # <- keyword.control.powershell
 #      ^ keyword.operator.assignment.powershell
 #                ^ punctuation.section.group.begin.powershell
-#                 ^ keyword.other.variable.definition.powershell
+#                 ^ punctuation.definition.variable.powershell
 #                   ^ punctuation.section.group.end.powershell
 #                     ^ meta.scriptblock.powershell punctuation.section.braces.begin.powershell
 #                      ^ meta.scriptblock.powershell punctuation.section.braces.end.powershell
@@ -617,7 +617,7 @@ switch (4, 2) {}
 switch -Regex -File $filePath {
 # <- keyword.control.powershell
 #      ^      ^ keyword.operator.assignment.powershell
-#                   ^ keyword.other.variable.definition.powershell
+#                   ^ punctuation.definition.variable.powershell
 #                             ^ meta.scriptblock.powershell punctuation.section.braces.begin.powershell
     '.' {}
 #   ^^^ string.quoted.single.powershell
@@ -634,7 +634,7 @@ switch -Wildcard -CaseSensitive ($something) {
 # <- keyword.control.powershell
 #      ^         ^ keyword.operator.assignment.powershell
 #                               ^ punctuation.section.group.begin.powershell
-#                                ^ keyword.other.variable.definition.powershell
+#                                ^ punctuation.definition.variable.powershell
 #                                 ^ variable.other.readwrite.powershell
 #                                          ^ punctuation.section.group.end.powershell
 #                                            ^ meta.scriptblock.powershell punctuation.section.braces.begin.powershell
@@ -711,7 +711,7 @@ function NewFile($Name) { }
 # <- storage.type.powershell
 #        ^^^^^^^ entity.name.function.powershell
 #               ^ punctuation.section.group.begin.powershell
-#                ^ keyword.other.variable.definition.powershell
+#                ^ punctuation.definition.variable.powershell
 #                   ^ variable.other.readwrite.powershell
 #                     ^ punctuation.section.group.end.powershell
 #                       ^ punctuation.section.braces.begin.powershell
@@ -720,7 +720,7 @@ filter myfilter($param) {}
 # <- storage.type.powershell
 #      ^^^^^^^^ entity.name.function.powershell
 #              ^ punctuation.section.group.begin.powershell
-#               ^ keyword.other.variable.definition.powershell
+#               ^ punctuation.definition.variable.powershell
 #                ^ variable.other.readwrite.powershell
 #                     ^ punctuation.section.group.end.powershell
 #                       ^ punctuation.section.braces.begin.powershell
@@ -729,7 +729,7 @@ Filter my-Filter ($param){}
 # <- storage.type.powershell
 #      ^^^^^^^^^ entity.name.function.powershell
 #                ^ punctuation.section.group.begin.powershell
-#                 ^ keyword.other.variable.definition.powershell
+#                 ^ punctuation.definition.variable.powershell
 #                   ^ variable.other.readwrite.powershell
 #                       ^ punctuation.section.group.end.powershell
 #                        ^ punctuation.section.braces.begin.powershell
@@ -743,12 +743,12 @@ function Test-Drive([string]$roman) {
 #                   ^ punctuation.section.bracket.begin.powershell
 #                    ^^^^^^ storage.type.powershell
 #                          ^ punctuation.section.bracket.end.powershell
-#                           ^ keyword.other.variable.definition.powershell
+#                           ^ punctuation.definition.variable.powershell
 #                            ^ variable.other.readwrite.powershell
 #                                 ^ punctuation.section.group.end.powershell
 #                                   ^ punctuation.section.braces.begin.powershell
     $roman | c:\users\Me\Documents\Programming\F#\test.exe $roman
-#   ^ keyword.other.variable.definition.powershell
+#   ^ punctuation.definition.variable.powershell
 #    ^ variable.other.readwrite.powershell
 #          ^ keyword.operator.other.powershell
 #                                               ^ punctuation.definition.comment.powershell
@@ -775,25 +775,25 @@ function Verb-Noun
         #         ^ meta.attribute.powershell punctuation.section.group.begin.powershell
         #          ^^^^^^^^^ meta.attribute.powershell variable.parameter.attribute.powershell
         #                   ^ meta.attribute.powershell keyword.operator.assignment.powershell
-        #                    ^ meta.attribute.powershell keyword.other.variable.definition.powershell
+        #                    ^ meta.attribute.powershell punctuation.definition.variable.powershell
         #                     ^^^^ meta.attribute.powershell constant.language.powershell
         #                         ^ meta.attribute.powershell keyword.operator.other.powershell
                    ValueFromPipeline=$true,
         #          ^^^^^^^^^^^^^^^^^ meta.attribute.powershell variable.parameter.attribute.powershell
         #                           ^ meta.attribute.powershell keyword.operator.assignment.powershell
-        #                            ^ meta.attribute.powershell keyword.other.variable.definition.powershell
+        #                            ^ meta.attribute.powershell punctuation.definition.variable.powershell
         #                             ^^^^ meta.attribute.powershell constant.language.powershell
         #                                 ^ meta.attribute.powershell keyword.operator.other.powershell
                    ValueFromPipelineByPropertyName = $true,
         #          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute.powershell variable.parameter.attribute.powershell
         #                                          ^ meta.attribute.powershell keyword.operator.assignment.powershell
-        #                                            ^ meta.attribute.powershell keyword.other.variable.definition.powershell
+        #                                            ^ meta.attribute.powershell punctuation.definition.variable.powershell
         #                                             ^^^^ meta.attribute.powershell constant.language.powershell
         #                                                 ^ meta.attribute.powershell keyword.operator.other.powershell
                    ValueFromRemainingArguments=$false,
         #          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute.powershell variable.parameter.attribute.powershell
         #                                     ^ meta.attribute.powershell keyword.operator.assignment.powershell
-        #                                      ^ meta.attribute.powershell keyword.other.variable.definition.powershell
+        #                                      ^ meta.attribute.powershell punctuation.definition.variable.powershell
         #                                       ^^^^^ meta.attribute.powershell constant.language.powershell
         #                                            ^ meta.attribute.powershell keyword.operator.other.powershell
                    Position=0,
@@ -856,7 +856,7 @@ function Verb-Noun
         #          ^ meta.attribute.powershell punctuation.section.group.end.powershell
         #           ^ meta.attribute.powershell punctuation.section.bracket.end.powershell
         $Param1
-        # <- keyword.other.variable.definition.powershell
+        # <- punctuation.definition.variable.powershell
         # ^ variable.other.readwrite.powershell
     )
     # <- punctuation.section.group.end.powershell
@@ -878,7 +878,7 @@ class Vehicle {
 #              ^ punctuation.section.braces.end.powershell
     Vehicle([string]$Owner) {
 #             ^ storage.type.powershell
-#                   ^ keyword.other.variable.definition.powershell
+#                   ^ punctuation.definition.variable.powershell
 #                    ^ variable.other.readwrite.powershell
 #                           ^ punctuation.section.braces.begin.powershell
         $this.Owner = $Owner
@@ -886,23 +886,23 @@ class Vehicle {
 
     [int]$Mileage
 #    ^ storage.type.powershell
-#        ^ keyword.other.variable.definition.powershell
+#        ^ punctuation.definition.variable.powershell
 #         ^ variable.other.readwrite.powershell
     [int]$Age
 #    ^ storage.type.powershell
-#        ^ keyword.other.variable.definition.powershell
+#        ^ punctuation.definition.variable.powershell
 #         ^ variable.other.readwrite.powershell
     [string]$Owner
 #    ^ storage.type.powershell
-#           ^ keyword.other.variable.definition.powershell
+#           ^ punctuation.definition.variable.powershell
 #            ^ variable.other.readwrite.powershell
 
     [void]Drive([int]$NumberOfMiles) {
 #    ^           ^ storage.type.powershell
-#                    ^ keyword.other.variable.definition.powershell
+#                    ^ punctuation.definition.variable.powershell
 #                     ^ variable.other.readwrite.powershell
         $this.Mileage += $NumberOfMiles
-#       ^ keyword.other.variable.definition.powershell
+#       ^ punctuation.definition.variable.powershell
 #        ^^^^ support.constant.automatic.powershell
 #             ^ variable.other.member.powershell
 #                     ^^ keyword.operator.assignment.powershell
@@ -919,7 +919,7 @@ foreach ($item in $collection) {
 #              ^^ keyword.control.powershell
 #                            ^ punctuation.section.group.end.powershell
 #                              ^ punctuation.section.braces.begin.powershell
-#        ^        ^ keyword.other.variable.definition.powershell
+#        ^        ^ punctuation.definition.variable.powershell
 }
 # <- punctuation.section.braces.end.powershell
 
@@ -998,7 +998,7 @@ $a -ceq 4 -and $a -ine $d -or
 #  ^              ^ keyword.operator.comparison.powershell
 #         ^               ^ keyword.operator.logical.powershell
 #       ^ constant.numeric.integer.powershell
-#              ^ keyword.other.variable.definition.powershell
+#              ^ punctuation.definition.variable.powershell
 $c -is [Type]
 #  ^ keyword.operator.comparison.powershell
 #       ^ storage.type.powershell
@@ -1158,16 +1158,16 @@ New-Object -TypeName System.Data
 #                      ^ keyword.control.powershell
 #                               ^ meta.scriptblock.powershell
 $file = join-path $env:SystemDrive "$([System.io.path]::GetRandomFileName()).ps1"
-# <- keyword.other.variable.definition.powershell
+# <- punctuation.definition.variable.powershell
 #            ^ support.function.powershell
 #                  ^ support.variable.drive.powershell
 #                         ^ variable.other.readwrite.powershell
-#                                   ^ string.quoted.double.powershell keyword.other.variable.definition.powershell
+#                                   ^ string.quoted.double.powershell punctuation.definition.variable.powershell
 #                                        ^ storage.type.powershell
 $ScriptBlock | Out-File $file -Force
-# <- keyword.other.variable.definition.powershell
+# <- punctuation.definition.variable.powershell
 #            ^ keyword.operator.other.powershell
-#                       ^ keyword.other.variable.definition.powershell
+#                       ^ punctuation.definition.variable.powershell
 #                             ^ keyword.operator.assignment.powershell
 workflow w1 {}
 # <- storage.type.powershell
@@ -1186,7 +1186,7 @@ get-thing | Out-WithYou > $null # destroy
 # ^          ^ support.function.powershell
 #         ^ keyword.operator.other.powershell
 #                       ^ keyword.operator.redirection.powershell
-#                         ^ keyword.other.variable.definition.powershell
+#                         ^ punctuation.definition.variable.powershell
 #                          ^ constant.language.powershell
 #                               ^ punctuation.definition.comment.powershell
 "Escaped chars: `", `n, `$, `b, `t, `""
@@ -1196,7 +1196,7 @@ get-thing | Out-WithYou > $null # destroy
 #             ^^ constant.character.escape.powershell
 #                                    ^^  ^^  ^^  ^^  ^^ not:constant.character.escape.powershell
 "When you call a method: $( get-number | %{ invoke-command $( [string]::format("Like (this{0})","what?") ) $var } )"
-#                        ^                                                                                 ^ keyword.other.variable.definition.powershell
+#                        ^                                                                                 ^ punctuation.definition.variable.powershell
 #                                      ^ keyword.operator.other.powershell
 #                                                           ^                 ^ meta.group.complex.subexpression.powershell punctuation.section.group.begin.powershell
 #                                                                ^ storage.type.powershell

--- a/spec/testfiles/syntax_test_TheBigTestFile.ps1
+++ b/spec/testfiles/syntax_test_TheBigTestFile.ps1
@@ -84,8 +84,9 @@ throw "Do not run this file!"
 & tool.exe /arg1 'value' /arg2 $value --% /arg3 $value /arg4 "value" # Comment
 # <- keyword.operator.other.powershell
 # ^^^^^^^^ support.function.powershell
-#          ^             ^                ^            ^ keyword.operator.assignment.powershell
+#          ^             ^ keyword.operator.assignment.powershell
 #                                     ^^^ keyword.control.powershell
+#                                         ^^    ^^     ^^    ^^      ^ ^ string.unquoted.powershell
 
 # Automatic variables
 $_

--- a/spec/testfiles/syntax_test_TheBigTestFile.ps1
+++ b/spec/testfiles/syntax_test_TheBigTestFile.ps1
@@ -110,20 +110,20 @@ $variable
 # <- keyword.other.variable.definition.powershell
 # ^ variable.other.readwrite.powershell
 $script:variable
-# <- keyword.other.variable.definition.powershell
+# <- keyword.other.variable.definition.powershell variable.other.readwrite.powershell
 # ^ storage.modifier.scope.powershell
 #       ^ variable.other.readwrite.powershell
 $ENV:ComputerName
-# <- keyword.other.variable.definition.powershell
+# <- keyword.other.variable.definition.powershell variable.other.readwrite.powershell
 # ^ support.variable.drive.powershell
 #    ^ variable.other.readwrite.powershell
 ${variable}
-# <- keyword.other.variable.definition.powershell
+# <- keyword.other.variable.definition.powershell variable.other.readwrite.powershell
  # <- punctuation.section.braces.begin.powershell
 # ^^^^^^^^ variable.other.readwrite.powershell
 #         ^ punctuation.section.braces.end.powershell
 ${script:variable}
-# <- keyword.other.variable.definition.powershell
+# <- keyword.other.variable.definition.powershell variable.other.readwrite.powershell
  # <- punctuation.section.braces.begin.powershell
 # ^ storage.modifier.scope.powershell
 #        ^ variable.other.readwrite.powershell
@@ -131,7 +131,7 @@ ${script:variable}
 
 # Variable properties should be highlighted
 $variable.Name
-# <- keyword.other.variable.definition.powershell
+# <- keyword.other.variable.definition.powershell variable.other.readwrite.powershell
 # ^ variable.other.readwrite.powershell
 #        ^^^^^ entity.name.function.invocation.powershell
 
@@ -250,7 +250,7 @@ $sb = {
 
 # Arrays
 $a1 = @(1,2,3,4)
-# <- keyword.other.variable.definition.powershell
+# <- keyword.other.variable.definition.powershell variable.other.readwrite.powershell
 # ^ variable.other.readwrite.powershell
 #   ^ keyword.operator.assignment.powershell
 #     ^ keyword.other.array.begin.powershell
@@ -259,7 +259,7 @@ $a1 = @(1,2,3,4)
 #       ^ ^ ^ ^ meta.group.array-expression.powershell constant.numeric.integer.powershell
 #        ^ ^ ^ meta.group.array-expression.powershell keyword.operator.other.powershell
 $a2 = ('one','two','three','four')
-# <- keyword.other.variable.definition.powershell
+# <- keyword.other.variable.definition.powershell variable.other.readwrite.powershell
 # ^ variable.other.readwrite.powershell
 #   ^ keyword.operator.assignment.powershell
 #     ^ punctuation.section.group.begin.powershell
@@ -267,25 +267,25 @@ $a2 = ('one','two','three','four')
 #           ^     ^       ^ keyword.operator.other.powershell
 #                                ^ punctuation.section.group.end.powershell
 $a3 = $one, $two, $three, $four
-# <- keyword.other.variable.definition.powershell
+# <- keyword.other.variable.definition.powershell variable.other.readwrite.powershell
 #     ^     ^     ^       ^ keyword.other.variable.definition.powershell
 # ^    ^     ^     ^       ^ variable.other.readwrite.powershell
 #   ^ keyword.operator.assignment.powershell
 #         ^     ^       ^ keyword.operator.other.powershell
 $a1[0]
-# <- keyword.other.variable.definition.powershell
+# <- keyword.other.variable.definition.powershell variable.other.readwrite.powershell
 # ^ variable.other.readwrite.powershell
 #  ^ punctuation.section.bracket.begin.powershell
 #   ^ constant.numeric.integer.powershell
 #    ^ punctuation.section.bracket.end.powershell
 $a2[-1]
-# <- keyword.other.variable.definition.powershell
+# <- keyword.other.variable.definition.powershell variable.other.readwrite.powershell
 # ^ variable.other.readwrite.powershell
 #  ^ punctuation.section.bracket.begin.powershell
 #   ^^ constant.numeric.integer.powershell
 #     ^ punctuation.section.bracket.end.powershell
 $a3[1..2]
-# <- keyword.other.variable.definition.powershell
+# <- keyword.other.variable.definition.powershell variable.other.readwrite.powershell
 # ^ variable.other.readwrite.powershell
 #  ^ punctuation.section.bracket.begin.powershell
 #   ^  ^ constant.numeric.integer.powershell
@@ -294,13 +294,13 @@ $a3[1..2]
     @(@($a))
 #   ^ ^ keyword.other.array.begin.powershell
 #    ^ ^ punctuation.section.group.begin.powershell
-#       ^ keyword.other.variable.definition.powershell
+#       ^ keyword.other.variable.definition.powershell variable.other.readwrite.powershell
 #        ^ variable.other.readwrite.powershell
 #         ^^ punctuation.section.group.end.powershell
     @(($i = 10); (++$j))
 #   ^ keyword.other.array.begin.powershell
 #    ^^          ^ punctuation.section.group.begin.powershell
-#      ^            ^ keyword.other.variable.definition.powershell
+#      ^            ^ keyword.other.variable.definition.powershell variable.other.readwrite.powershell
 #       ^            ^ variable.other.readwrite.powershell
 #         ^ keyword.operator.assignment.powershell
 #           ^^ constant.numeric.integer.powershell
@@ -310,13 +310,13 @@ $a3[1..2]
     @($i = 10)
 #   ^ keyword.other.array.begin.powershell
 #    ^ punctuation.section.group.begin.powershell
-#     ^ keyword.other.variable.definition.powershell
+#     ^ keyword.other.variable.definition.powershell variable.other.readwrite.powershell
 #      ^ variable.other.readwrite.powershell
 #        ^ keyword.operator.assignment.powershell
 #          ^^ constant.numeric.integer.powershell
 #            ^ punctuation.section.group.end.powershell
     $i[($y - 1) + $x]
-#   ^   ^         ^ keyword.other.variable.definition.powershell
+#   ^   ^         ^ keyword.other.variable.definition.powershell variable.other.readwrite.powershell
 #    ^   ^         ^ variable.other.readwrite.powershell
 #     ^ punctuation.section.bracket.begin.powershell
 #      ^ punctuation.section.group.begin.powershell
@@ -345,7 +345,7 @@ $a3[1..2]
 #   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double.powershell
     "$This is a double ""quoted"" string."
 #   ^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double.powershell
-#    ^ keyword.other.variable.definition.powershell
+#    ^ keyword.other.variable.definition.powershell support.variable.automatic.powershell
 #     ^^^^ support.variable.automatic.powershell
     "This is a
     double quoted string."
@@ -436,7 +436,7 @@ Isn't it "nice"??
     -2..$null
 #   ^^ constant.numeric.integer.powershell
 #     ^^ keyword.operator.range.powershell
-#       ^ keyword.other.variable.definition.powershell
+#       ^ keyword.other.variable.definition.powershell constant.language.powershell
 #        ^^^^ constant.language.powershell
     -3..3
 #   ^^  ^ constant.numeric.integer.powershell

--- a/spec/testfiles/syntax_test_TheBigTestFile.ps1
+++ b/spec/testfiles/syntax_test_TheBigTestFile.ps1
@@ -71,7 +71,7 @@ using namespace System.Management.Automation
 #                                ^^^^^^^^^^ meta.requires.powershell meta.hashtable.powershell variable.other.readwrite.powershell
 #                                          ^ meta.requires.powershell meta.hashtable.powershell
 #                                           ^^^^^^^^^^^^^^^^ meta.requires.powershell meta.hashtable.powershell string.quoted.double.powershell
-#                                                           ^ meta.requires.powershell meta.hashtable.powershell keyword.other.statement-separator.powershell
+#                                                           ^ meta.requires.powershell meta.hashtable.powershell punctuation.terminator.statement.powershell
 #                                                             ^^^^^^^^^^^^^ meta.requires.powershell meta.hashtable.powershell variable.other.readwrite.powershell
 #                                                                          ^ meta.requires.powershell meta.hashtable.powershell
 #                                                                           ^^^^^^^^^ meta.requires.powershell meta.hashtable.powershell string.quoted.double.powershell
@@ -294,7 +294,7 @@ $a3[1..2]
 #       ^            ^ variable.other.readwrite.powershell
 #         ^ keyword.operator.assignment.powershell
 #           ^^ constant.numeric.integer.powershell
-#              ^ keyword.other.statement-separator.powershell
+#              ^ punctuation.terminator.statement.powershell
 #                 ^^ keyword.operator.assignment.powershell
 #             ^       ^^ punctuation.section.group.end.powershell
     @($i = 10)


### PR DESCRIPTION
* The `$` is now scoped `punctuation.definition.variable.powershell` which is correct but also has the same scope as the variable itself. In themes that define `punctuation.definition.variable` it will use those colours but in themes that do not it will be the same colour as the variable. This fixes #23.

* The `;` has been rescoped. This fixes #114.

* The `'` and `"` characters that open and close strings have been rescoped. This fixes #110.

* Per #107 variable members have been rescoped. Issue still requires work.

* Everything following `--%` has been rescoped. This fixes #113.