### PR TITLE
also scope the \n at the end of line comments as `comment.line`

### DIFF
--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -398,7 +398,7 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>$</string>
+			<string>$\n?</string>
 			<key>name</key>
 			<string>comment.line.powershell</string>
 			<key>patterns</key>


### PR DESCRIPTION
Fixes #123.

Note that it doesn't seem possible to create a test assertion for it until https://github.com/PowerShell/EditorSyntax/issues/124 is addressed, [as `atom-grammar-test` doesn't seem to support tokens on `\n` characters](https://github.com/kevinastone/atom-grammar-test/blob/ba6f41169469088d8ade26dd0bebf318ba5f220b/spec/io-spec.js#L27-L30) - when I try, I just get an error:

> Expected to find comment.line.powershell at 769:34, instead found no token