### PR TITLE
Fixes @splatting in double quoted strings

### DIFF
--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -1393,7 +1393,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(?i:(\$|@)(global|local|private|script|using|workflow):((?:\p{L}|\d|_)+))</string>
+					<string>(?i:(\$)(global|local|private|script|using|workflow):((?:\p{L}|\d|_)+))</string>
 				</dict>
 				<dict>
 					<key>captures</key>
@@ -1591,10 +1591,6 @@
 				<dict>
 					<key>include</key>
 					<string>#variableNoProperty</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#variable</string>
 				</dict>
 				<dict>
 					<key>include</key>

--- a/spec/testfiles/syntax_test_TheBigTestFile.ps1
+++ b/spec/testfiles/syntax_test_TheBigTestFile.ps1
@@ -173,6 +173,12 @@ $variable.Name
 #                                       ^^^^^^^^^^^^ variable.other.readwrite.powershell
 #                                                    ^ punctuation.definition.string.end.powershell
 
+# @splat references only work in argument mode, should not highlight in strings
+"This is a @double quoted string."
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double.powershell
+#          ^ not:punctuation.definition.variable.powershell
+#           ^ not:variable.other.readwrite.powershell
+
 # Single quotes string
 'This is a string'
 # <- punctuation.definition.string.begin.powershell string.quoted.single.powershell
@@ -369,6 +375,9 @@ $This is a 'double quoted'
 # <- punctuation.definition.variable.powershell
 # ^ string.quoted.double.heredoc.powershell support.variable.automatic.powershell
 Isn't it "nice"??
+There is no @platting here!
+#           ^ not:punctuation.definition.variable.powershell
+#            ^ not:variable.other.readwrite.powershell
 "@
 # <- string.quoted.double.heredoc.powershell
  # <- string.quoted.double.heredoc.powershell


### PR DESCRIPTION
fixes #149, fixes #164

Include of `#variable` was removed from #doubleQuotedString, and a alternation of `@` was removed from a match in `#variableNoProperty` for variables that had a scope modifier.

Double quoted HereDocs do not exhibit this problem, they do not include `#variable`.

```PowerShell
"No @splats.wanted here"
"No @global:splats allowed here"
```

I'm not noticing any side effects.

This makes no attempt to improve any other part of the variable logic (such as @splats are not allowed to have member access).