### PR TITLE
Fixes for automatic variables

### DIFF
--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -1042,7 +1042,7 @@
 						<key>0</key>
 						<dict>
 							<key>name</key>
-							<string>support.constant.automatic.powershell</string>
+							<string>support.variable.automatic.powershell</string>
 						</dict>
 						<key>1</key>
 						<dict>
@@ -1058,7 +1058,7 @@
 					<key>comment</key>
 					<string>Automatic variables are not constants, but they are read-only. In monokai (default) color schema support.variable doesn't have color, so we use constant.</string>
 					<key>match</key>
-					<string>(\$)(?i:(\$|\^|\?|_|Args|ConsoleFileName|Event|EventArgs|EventSubscriber|ForEach|Input|LastExitCode|Matches|MyInvocation|NestedPromptLevel|Profile|PSBoundParameters|PsCmdlet|PsCulture|PSDebugContext|PSItem|PSCommandPath|PSScriptRoot|PsUICulture|Pwd|Sender|SourceArgs|SourceEventArgs|StackTrace|Switch|This))((?:\.(?:\p{L}|\d|_)+)*\b)?\b</string>
+					<string>(\$)((?:[$^?])|(?i:_|Args|ConsoleFileName|Event|EventArgs|EventSubscriber|ForEach|Input|LastExitCode|Matches|MyInvocation|NestedPromptLevel|Profile|PSBoundParameters|PsCmdlet|PsCulture|PSDebugContext|PSItem|PSCommandPath|PSScriptRoot|PsUICulture|Pwd|Sender|SourceArgs|SourceEventArgs|StackTrace|Switch|This)\b)((?:\.(?:\p{L}|\d|_)+)*\b)?</string>
 				</dict>
 				<dict>
 					<key>captures</key>
@@ -1342,7 +1342,7 @@
 					<key>comment</key>
 					<string>Automatic variables are not constants, but they are read-only...</string>
 					<key>match</key>
-					<string>(\$)(?i:(\$|\^|\?|_|Args|ConsoleFileName|Event|EventArgs|EventSubscriber|ForEach|Input|LastExitCode|Matches|MyInvocation|NestedPromptLevel|Profile|PSBoundParameters|PsCmdlet|PsCulture|PSDebugContext|PSItem|PSCommandPath|PSScriptRoot|PsUICulture|Pwd|Sender|SourceArgs|SourceEventArgs|StackTrace|Switch|This))\b</string>
+					<string>(\$)((?:[$^?])|(?i:_|Args|ConsoleFileName|Event|EventArgs|EventSubscriber|ForEach|Input|LastExitCode|Matches|MyInvocation|NestedPromptLevel|Profile|PSBoundParameters|PsCmdlet|PsCulture|PSDebugContext|PSItem|PSCommandPath|PSScriptRoot|PsUICulture|Pwd|Sender|SourceArgs|SourceEventArgs|StackTrace|Switch|This)\b)</string>
 				</dict>
 				<dict>
 					<key>captures</key>

--- a/spec/testfiles/syntax_test_Class.ps1
+++ b/spec/testfiles/syntax_test_Class.ps1
@@ -63,7 +63,7 @@ class TypeName
         #                ^ punctuation.section.group.end.powershell
         $this.P1 = $s
         # <- punctuation.definition.variable.powershell
-        # ^ support.constant.automatic.powershell
+        # ^ support.variable.automatic.powershell
         #     ^^ variable.other.member.powershell
         #        ^ keyword.operator.assignment.powershell
         #          ^ punctuation.definition.variable.powershell
@@ -110,7 +110,7 @@ class TypeName
     #                           ^ punctuation.section.group.end.powershell
         $this.P3 = $i
         # <- punctuation.definition.variable.powershell
-        # ^ support.constant.automatic.powershell
+        # ^ support.variable.automatic.powershell
         #     ^^ variable.other.member.powershell
         #        ^ keyword.operator.assignment.powershell
         #          ^ punctuation.definition.variable.powershell
@@ -118,7 +118,7 @@ class TypeName
         return $this.P3
         # <- keyword.control.powershell
         #      ^ punctuation.definition.variable.powershell
-        #       ^^^^ support.constant.automatic.powershell
+        #       ^^^^ support.variable.automatic.powershell
         #            ^^ variable.other.member.powershell
     }
 }

--- a/spec/testfiles/syntax_test_Function.ps1
+++ b/spec/testfiles/syntax_test_Function.ps1
@@ -305,7 +305,7 @@ function Verb-Noun {
         #               ^ meta.attribute.powershell meta.scriptblock.powershell
         #                ^^^^^^^^^ meta.scriptblock.powershell support.function.powershell
         #                          ^ meta.scriptblock.powershell punctuation.definition.variable.powershell
-        #                           ^ meta.scriptblock.powershell support.constant.automatic.powershell
+        #                           ^ meta.scriptblock.powershell support.variable.automatic.powershell
         #                            ^ meta.attribute.powershell meta.scriptblock.powershell
         #                             ^ meta.attribute.powershell punctuation.section.group.end.powershell
         #                              ^ meta.attribute.powershell punctuation.section.bracket.end.powershell
@@ -359,7 +359,7 @@ function Verb-Noun {
         # <- keyword.control.powershell
         #  ^ punctuation.section.group.begin.powershell
         #   ^ punctuation.definition.variable.powershell
-        #    ^^^^^^^^ support.constant.automatic.powershell
+        #    ^^^^^^^^ support.variable.automatic.powershell
         #             ^^^^^^^^^^^^^ variable.other.member.powershell
         #                          ^ punctuation.section.group.begin.powershell
         #                                                ^ punctuation.section.group.end.powershell

--- a/spec/testfiles/syntax_test_TheBigTestFile.ps1
+++ b/spec/testfiles/syntax_test_TheBigTestFile.ps1
@@ -91,10 +91,10 @@ throw "Do not run this file!"
 # Automatic variables
 $_
 # <- punctuation.definition.variable.powershell
- # <- support.constant.automatic.powershell
+ # <- support.variable.automatic.powershell
 $args
 # <- punctuation.definition.variable.powershell
-# ^ support.constant.automatic.powershell
+# ^ support.variable.automatic.powershell
 $error
 # <- punctuation.definition.variable.powershell
 # ^ support.constant.variable.powershell
@@ -103,7 +103,7 @@ $home
 # ^ support.constant.variable.powershell
 $foreach
 # <- punctuation.definition.variable.powershell
-# ^ support.constant.automatic.powershell
+# ^ support.variable.automatic.powershell
 
 # Normal variables
 $variable
@@ -912,7 +912,7 @@ class Vehicle {
 #                     ^ variable.other.readwrite.powershell
         $this.Mileage += $NumberOfMiles
 #       ^ punctuation.definition.variable.powershell
-#        ^^^^ support.constant.automatic.powershell
+#        ^^^^ support.variable.automatic.powershell
 #             ^ variable.other.member.powershell
 #                     ^^ keyword.operator.assignment.powershell
 

--- a/spec/testfiles/syntax_test_TheBigTestFile.ps1
+++ b/spec/testfiles/syntax_test_TheBigTestFile.ps1
@@ -89,9 +89,15 @@ throw "Do not run this file!"
 #                                         ^^    ^^     ^^    ^^      ^ ^ string.unquoted.powershell
 
 # Automatic variables
-$_
+$_, $$, $^, $?
 # <- punctuation.definition.variable.powershell
  # <- support.variable.automatic.powershell
+#   ^ punctuation.definition.variable.powershell
+#    ^ support.variable.automatic.powershell
+#       ^ punctuation.definition.variable.powershell
+#        ^ support.variable.automatic.powershell
+#           ^ punctuation.definition.variable.powershell
+#            ^ support.variable.automatic.powershell
 $args
 # <- punctuation.definition.variable.powershell
 # ^ support.variable.automatic.powershell
@@ -178,6 +184,12 @@ $variable.Name
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double.powershell
 #          ^ not:punctuation.definition.variable.powershell
 #           ^ not:variable.other.readwrite.powershell
+
+# double check scopes for automatic variables in strings
+"$_ $$ $Pwd"
+# ^ support.variable.automatic.powershell
+#    ^ support.variable.automatic.powershell
+#       ^ support.variable.automatic.powershell
 
 # Single quotes string
 'This is a string'


### PR DESCRIPTION
Fixes #133.

This corrects the regex used for matching `$$`, `$^` and `$?` automatic variables.  This occurs because the current regex can be simplified to `\$[$^?]\b`, but the `\b` (word boundary) fails if one of the two characters tested at the boundary is not a word character (one must be a word, one must not be a word, and the set `[$^?]` contains no word characters).  As such, only very limited cases would have successfully matched.  A boundary test is not required for these particular patterns.  `$_` is not affected because `_` is a word character, and so it has been left in the part of the regex that still applies the boundary test (and is actually required).

This also fixes the mismatch of scopes for these same variables and the larger set specified in the same regex(s), between `#variable` and `#variableNoProperty`, by adopting `support.variable.automatic.powershell` in both places.

Tests have been corrected for the scope change, and then updated to include tests specific to the two conditions being resolved.