### PR TITLE
Adds new PowerShell Core escapes `e and `u{x} (#60)

### DIFF
--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -662,15 +662,39 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>`[0abnfrvt"'$`]</string>
+					<string>`[`0abefnrtv"'$]</string>
 					<key>name</key>
 					<string>constant.character.escape.powershell</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#unicodeEscape</string>
 				</dict>
 				<dict>
 					<key>match</key>
 					<string>""</string>
 					<key>name</key>
 					<string>constant.character.escape.powershell</string>
+				</dict>
+			</array>
+		</dict>
+		<key>unicodeEscape</key>
+		<dict>
+			<key>comment</key>
+			<string>`u{xxxx} added in PowerShell 6.0</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>`u\{(?:(?:10)?([0-9a-fA-F]){1,4}|0?\g&lt;1&gt;{1,5})}</string>
+					<key>name</key>
+					<string>constant.character.escape.powershell</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>`u(?:\{[0-9a-fA-F]{,6}.)?</string>
+					<key>name</key>
+					<string>invalid.character.escape.powershell</string>
 				</dict>
 			</array>
 		</dict>

--- a/spec/testfiles/syntax_test_TheBigTestFile.ps1
+++ b/spec/testfiles/syntax_test_TheBigTestFile.ps1
@@ -1198,9 +1198,9 @@ get-thing | Out-WithYou > $null # destroy
 #                         ^ punctuation.definition.variable.powershell
 #                          ^ constant.language.powershell
 #                               ^ punctuation.definition.comment.powershell
-"Escaped chars: `", `n, `$, `b, `t, `""
+"Escaped chars: `", `n, `$, `b, `t, `e, `u{10ffff}, `""
 # <- string.quoted.double.powershell
-#               ^^  ^^  ^^  ^^  ^^  ^^ string.quoted.double.powershell constant.character.escape.powershell
+#               ^^  ^^  ^^  ^^  ^^  ^^  ^^^^^^^^^^  ^^ string.quoted.double.powershell constant.character.escape.powershell
 'But here they''re not escape chars: `", `n, `$, `b, `"'
 #             ^^ constant.character.escape.powershell
 #                                    ^^  ^^  ^^  ^^  ^^ not:constant.character.escape.powershell


### PR DESCRIPTION
Adds syntax highlighting support for ``` `e ``` (escape, `^[` or `[char]27`) and the Unicode entity escape ``` `u{x} ``` where `x` is 1-6 hex digits ranging in value from 0x0 to 0x10FFFF.

Adds simple tests for both.

Note, invalid use of ``` `u ``` will scope as `invalid.character.escape.powershell`
![image](https://user-images.githubusercontent.com/26179051/57350465-c8e8ba00-7123-11e9-8376-354704583ee6.png)

I added a new repository item immediately below 'doubleQuotedStringEscapes' so that 'unicodeEscapes' could be reused.  (#156 uses the same item 3 times)

(Closes) Fixes #60.

