### PR TITLE
Remove redundant includes from #attribute (#168)

### DIFF
--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -469,42 +469,6 @@
 					<array>
 						<dict>
 							<key>include</key>
-							<string>#variable</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#variableNoProperty</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#hashtable</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#scriptblock</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#doubleQuotedStringEscapes</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#doubleQuotedString</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#type</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#numericConstant</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#doubleQuotedString</string>
-						</dict>
-						<dict>
-							<key>include</key>
 							<string>$self</string>
 						</dict>
 						<dict>
@@ -523,39 +487,6 @@
 									<string>keyword.operator.assignment.powershell</string>
 								</dict>
 							</dict>
-						</dict>
-						<dict>
-							<key>begin</key>
-							<string>(?&lt;!')'</string>
-							<key>beginCaptures</key>
-							<dict>
-								<key>0</key>
-								<dict>
-									<key>name</key>
-									<string>punctuation.definition.string.begin.powershell</string>
-								</dict>
-							</dict>
-							<key>end</key>
-							<string>'(?!')</string>
-							<key>endCaptures</key>
-							<dict>
-								<key>0</key>
-								<dict>
-									<key>name</key>
-									<string>punctuation.definition.string.end.powershell</string>
-								</dict>
-							</dict>
-							<key>name</key>
-							<string>string.quoted.single.powershell</string>
-							<key>patterns</key>
-							<array>
-								<dict>
-									<key>match</key>
-									<string>''</string>
-									<key>name</key>
-									<string>constant.character.escape.powershell</string>
-								</dict>
-							</array>
 						</dict>
 					</array>
 				</dict>


### PR DESCRIPTION
This PR removes all redundant includes from #attribute.

Fixes #168.

Applying this PR before applying a PR for #141 would reduce the number of lines needed to be changed in the later PR.  

A PR for #143 could also fix the issue behind #168, but I think this PR is the right solution, as it cleans up unnecessary items, and eliminates the root cause.
