### PR TITLE
Fix and enhance mulitple quoted string issues

### DIFF
--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -101,7 +101,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(?&lt;!')'</string>
+			<string>['\x{2018}-\x{201B}]</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>0</key>
@@ -111,7 +111,9 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>'(?!')</string>
+			<string>['\x{2018}-\x{201B}]</string>
+			<key>applyEndPatternLast</key>
+			<true/>
 			<key>endCaptures</key>
 			<dict>
 				<key>0</key>
@@ -126,7 +128,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>''</string>
+					<string>['\x{2018}-\x{201B}]{2}</string>
 					<key>name</key>
 					<string>constant.character.escape.powershell</string>
 				</dict>
@@ -134,9 +136,9 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>\@"\s*$</string>
+			<string>\@["\x{201C}-\x{201E}]\s*$</string>
 			<key>end</key>
-			<string>^"@</string>
+			<string>^["\x{201C}-\x{201E}]@</string>
 			<key>name</key>
 			<string>string.quoted.double.heredoc.powershell</string>
 			<key>patterns</key>
@@ -157,9 +159,9 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>\@'\s*$</string>
+			<string>\@['\x{2018}-\x{201B}]\s*$</string>
 			<key>end</key>
-			<string>^'@</string>
+			<string>^['\x{2018}-\x{201B}]@</string>
 			<key>name</key>
 			<string>string.quoted.single.heredoc.powershell</string>
 		</dict>
@@ -584,7 +586,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>`[`0abefnrtv"'$]</string>
+					<string>`[`0abefnrtv'"\x{2018}-\x{201E}$]</string>
 					<key>name</key>
 					<string>constant.character.escape.powershell</string>
 				</dict>
@@ -1501,7 +1503,7 @@
 		<key>doubleQuotedString</key>
 		<dict>
 			<key>begin</key>
-			<string>(?&lt;!(?&lt;!`)")"</string>
+			<string>["\x{201C}-\x{201E}]</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>0</key>
@@ -1511,7 +1513,9 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>"(?!")</string>
+			<string>["\x{201C}-\x{201E}]</string>
+			<key>applyEndPatternLast</key>
+			<true/>
 			<key>endCaptures</key>
 			<dict>
 				<key>0</key>
@@ -1538,7 +1542,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>""</string>
+					<string>["\x{201C}-\x{201E}]{2}</string>
 					<key>name</key>
 					<string>constant.character.escape.powershell</string>
 				</dict>

--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -162,15 +162,6 @@
 			<string>^'@</string>
 			<key>name</key>
 			<string>string.quoted.single.heredoc.powershell</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>match</key>
-					<string>''</string>
-					<key>name</key>
-					<string>constant.character.escape.powershell</string>
-				</dict>
-			</array>
 		</dict>
 		<dict>
 			<key>include</key>
@@ -600,12 +591,6 @@
 				<dict>
 					<key>include</key>
 					<string>#unicodeEscape</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>""</string>
-					<key>name</key>
-					<string>constant.character.escape.powershell</string>
 				</dict>
 			</array>
 		</dict>
@@ -1550,6 +1535,12 @@
 				<dict>
 					<key>include</key>
 					<string>#doubleQuotedStringEscapes</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>""</string>
+					<key>name</key>
+					<string>constant.character.escape.powershell</string>
 				</dict>
 				<dict>
 					<key>include</key>

--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -136,9 +136,25 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>\@["\x{201C}-\x{201E}]\s*$</string>
+			<string>(@["\x{201C}-\x{201E}])\s*$</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.string.begin.powershell</string>
+				</dict>
+			</dict>
 			<key>end</key>
 			<string>^["\x{201C}-\x{201E}]@</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.string.end.powershell</string>
+				</dict>
+			</dict>
 			<key>name</key>
 			<string>string.quoted.double.heredoc.powershell</string>
 			<key>patterns</key>
@@ -159,9 +175,25 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>\@['\x{2018}-\x{201B}]\s*$</string>
+			<string>(@['\x{2018}-\x{201B}])\s*$</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.string.begin.powershell</string>
+				</dict>
+			</dict>
 			<key>end</key>
 			<string>^['\x{2018}-\x{201B}]@</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.string.end.powershell</string>
+				</dict>
+			</dict>
 			<key>name</key>
 			<string>string.quoted.single.heredoc.powershell</string>
 		</dict>

--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -134,7 +134,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>\@"(?=$)</string>
+			<string>\@"\s*$</string>
 			<key>end</key>
 			<string>^"@</string>
 			<key>name</key>
@@ -157,7 +157,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>\@'(?=$)</string>
+			<string>\@'\s*$</string>
 			<key>end</key>
 			<string>^'@</string>
 			<key>name</key>

--- a/spec/testfiles/syntax_test_TheBigTestFile.ps1
+++ b/spec/testfiles/syntax_test_TheBigTestFile.ps1
@@ -379,20 +379,37 @@ $a3[1..2]
     "This 'string' is nice."
 #   ^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double.powershell
 
-# Double quoted here-string
-@"
+# Double quoted here-string, white space at end of start token allowed
+@"  
 # <- string.quoted.double.heredoc.powershell
  # <- string.quoted.double.heredoc.powershell
 $This is a 'double quoted'
 # <- punctuation.definition.variable.powershell
 # ^ string.quoted.double.heredoc.powershell support.variable.automatic.powershell
-Isn't it "nice"??
+Isn't it ""nice""??
+#        ^^ not:constant.character.escape.powershell
 There is no @platting here!
 #           ^ not:punctuation.definition.variable.powershell
 #            ^ not:variable.other.readwrite.powershell
 "@
 # <- string.quoted.double.heredoc.powershell
  # <- string.quoted.double.heredoc.powershell
+
+# Single quoted here-string, white space at end of start token allowed
+@'  
+# <- string.quoted.single.heredoc.powershell
+ # <- string.quoted.single.heredoc.powershell
+$This is a ''single quoted''
+#          ^^ not:constant.character.escape.powershell
+# <- not:punctuation.definition.variable.powershell
+# ^ string.quoted.single.heredoc.powershell not:support.variable.automatic.powershell
+Isn't it "nice"??
+There is no @platting here!
+#           ^ not:punctuation.definition.variable.powershell
+#            ^ not:variable.other.readwrite.powershell
+'@
+# <- string.quoted.single.heredoc.powershell
+ # <- string.quoted.single.heredoc.powershell
 
 # Numeric constants
     -3


### PR DESCRIPTION
- Fixes #143, moving the double double-quote escape (`""`) in to `doubleQuotedString` from `doubleQuotedStringEscapes`, and removing the double single-quote escape (`''`) from the pattern for single quoted here-strings.
- Fixes #167 (entirely), permitting white space to follow the opening token for here-strings, adding punctuation scopes to the start and end tokens (`punctuation.definition.string…`), and preparing some of the string regex's for the following change.

- Closes #141, applying the PowerShell supported curly quotes `\x{2018}-\x{201B}` (single  quotes) and `\x{201C}-\x{201E}` (double quotes), everywhere except for an occurrence in `hashtable`:

   https://github.com/PowerShell/EditorSyntax/blob/44eac8702f3cbe55a4ec70c1fdb163d42b4162fc/PowerShellSyntax.tmLanguage#L1501-L1504

   There are issues in this area, that nearly make the quotes in this section unusable.

- Tests added for single quoted here-string, and the escaping issue of #143.  There are currently no tests I found for `punctuation.definition.string…` for any kind of strings.

