### PR TITLE
Improvements to Comment Based Help Keywords

### DIFF
--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -388,10 +388,10 @@
 		<key>commentLine</key>
 		<dict>
 			<key>begin</key>
-			<string>(?&lt;![`\\-])#</string>
+			<string>(?&lt;![`\\-])(#)#*</string>
 			<key>captures</key>
 			<dict>
-				<key>0</key>
+				<key>1</key>
 				<dict>
 					<key>name</key>
 					<string>punctuation.definition.comment.powershell</string>
@@ -556,8 +556,10 @@
 							<string>keyword.operator.documentation.powershell</string>
 						</dict>
 					</dict>
+					<key>comment</key>
+					<string>these embedded doc keywords do not support arguments, must be the only thing on the line</string>
 					<key>match</key>
-					<string>^(?i:(?:\s?|#)+(\.)(COMPONENT|DESCRIPTION|EXAMPLE|EXTERNALHELP|FORWARDHELPCATEGORY|FORWARDHELPTARGETNAME|FUNCTIONALITY|INPUTS|LINK|NOTES|OUTPUTS|REMOTEHELPRUNSPACE|ROLE|SYNOPSIS))</string>
+					<string>(?:^|\G)(?i:\s*(\.)(COMPONENT|DESCRIPTION|EXAMPLE|FUNCTIONALITY|INPUTS|LINK|NOTES|OUTPUTS|ROLE|SYNOPSIS))\s*$</string>
 					<key>name</key>
 					<string>comment.documentation.embedded.powershell</string>
 				</dict>
@@ -580,8 +582,10 @@
 							<string>keyword.operator.documentation.powershell</string>
 						</dict>
 					</dict>
+					<key>comment</key>
+					<string>these embedded doc keywords require arguments though the type required may be inconsistent, they may not all be able to use the same argument match</string>
 					<key>match</key>
-					<string>(?i:\s?(\.)(PARAMETER|FORWARDHELPTARGETNAME|FORWARDHELPCATEGORY|REMOTEHELPRUNSPACE|EXTERNALHELP)\s+([a-z0-9-_]+))</string>
+					<string>(?:^|\G)(?i:\s*(\.)(EXTERNALHELP|FORWARDHELP(?:CATEGORY|TARGETNAME)|PARAMETER|REMOTEHELPRUNSPACE))\s+(.+?)\s*$</string>
 					<key>name</key>
 					<string>comment.documentation.embedded.powershell</string>
 				</dict>


### PR DESCRIPTION
Fixes #136

This PR improves the scoping of comment based help keywords, specifically fixing the lack of highlighting for the keywords that do not accept arguments when used on single-line comment lines.

This required an optimization to the single-line comment (`commentLine`), and tweaks to the `commentEmbeddedDocs` matches.  By utilizing a `^|\G` pattern, it can be prevented that extra `#` be still permitted to match, which PowerShell does not permit.  I also organized the keywords on their prospective matches alphabetically.  On the match for keywords with arguments, I opened up the argument capture to all the available text, as there seems to be no additional rules that limit what PowerShell will accept.

There are no tests that cover this particular condition, since the testing engine uses single-line comments to hide the test expressions.  `commentBlock` tests have not changed.

I am sure that #134 has not been reintroduced.