### PR TITLE
Embedded subexpressions

### DIFF
--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -63,7 +63,7 @@
 		</dict>
 		<dict>
 			<key>include</key>
-			<string>#interpolatedStringContent</string>
+			<string>#subexpression</string>
 		</dict>
 		<dict>
 			<key>include</key>
@@ -214,15 +214,20 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(\$)(\()</string>
+			<string>((\$))(\()</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.variable.powershell</string>
+					<string>keyword.other.substatement.powershell</string>
 				</dict>
 				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.subexpression.powershell</string>
+				</dict>
+				<key>3</key>
 				<dict>
 					<key>name</key>
 					<string>punctuation.section.group.begin.powershell</string>
@@ -666,7 +671,7 @@
 				</dict>
 			</array>
 		</dict>
-		<key>interpolatedStringContent</key>
+		<key>subexpression</key>
 		<dict>
 			<key>begin</key>
 			<string>\(</string>
@@ -678,8 +683,6 @@
 					<string>punctuation.section.group.begin.powershell</string>
 				</dict>
 			</dict>
-			<key>contentName</key>
-			<string>interpolated.simple.source.powershell</string>
 			<key>end</key>
 			<string>\)</string>
 			<key>endCaptures</key>
@@ -690,43 +693,52 @@
 					<string>punctuation.section.group.end.powershell</string>
 				</dict>
 			</dict>
+			<key>name</key>
+			<string>meta.group.simple.subexpression.powershell</string>
 			<key>patterns</key>
 			<array>
 				<dict>
 					<key>include</key>
 					<string>$self</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#interpolation</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#interpolatedStringContent</string>
 				</dict>
 			</array>
 		</dict>
 		<key>interpolation</key>
 		<dict>
 			<key>begin</key>
-			<string>(\$)(\()</string>
+			<string>(((\$)))((\())</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.variable.powershell</string>
+					<string>keyword.other.substatement.powershell</string>
 				</dict>
 				<key>2</key>
 				<dict>
 					<key>name</key>
+					<string>punctuation.definition.substatement.powershell</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.section.embedded.substatement.begin.powershell</string>
+				</dict>
+				<key>4</key>
+				<dict>
+					<key>name</key>
 					<string>punctuation.section.group.begin.powershell</string>
+				</dict>
+				<key>5</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.section.embedded.substatement.begin.powershell</string>
 				</dict>
 			</dict>
 			<key>contentName</key>
 			<string>interpolated.complex.source.powershell</string>
 			<key>end</key>
-			<string>\)</string>
+			<string>(\))</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>0</key>
@@ -734,20 +746,19 @@
 					<key>name</key>
 					<string>punctuation.section.group.end.powershell</string>
 				</dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.section.embedded.substatement.end.powershell</string>
+				</dict>
 			</dict>
+			<key>name</key>
+			<string>meta.embedded.substatement.powershell</string>
 			<key>patterns</key>
 			<array>
 				<dict>
 					<key>include</key>
 					<string>$self</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#interpolation</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#interpolatedStringContent</string>
 				</dict>
 			</array>
 		</dict>

--- a/spec/testfiles/syntax_test_TheBigTestFile.ps1
+++ b/spec/testfiles/syntax_test_TheBigTestFile.ps1
@@ -153,7 +153,11 @@ $variable.Name
 "This is my $($variable.Name)!"
 # <- punctuation.definition.string.begin.powershell string.quoted.double.powershell
 # ^^^^^^^^^^                 ^^ string.quoted.double.powershell
-#           ^ ^ punctuation.definition.variable.powershell
+#           ^^ punctuation.section.embedded.substatement.begin.powershell
+#                           ^ punctuation.section.embedded.substatement.end.powershell
+#           ^^^^^^^^^^^^^^^^^ meta.embedded.substatement.powershell
+#           ^ keyword.other.substatement.powershell
+#             ^ punctuation.definition.variable.powershell
 #            ^ punctuation.section.group.begin.powershell
 #                           ^ punctuation.section.group.end.powershell
 #              ^^^^^^^^ variable.other.readwrite.powershell
@@ -372,7 +376,10 @@ $a3[1..2]
 #   ^^^^^^^^^^^^ string.quoted.double.powershell
     "$(Invoke-Something)"
 #   ^                   ^ string.quoted.double.powershell
-#    ^ punctuation.definition.variable.powershell
+#    ^^ punctuation.section.embedded.substatement.begin.powershell
+#                      ^ punctuation.section.embedded.substatement.end.powershell
+#    ^^^^^^^^^^^^^^^^^^^ meta.embedded.substatement.powershell
+#    ^ keyword.other.substatement.powershell
 #     ^ punctuation.section.group.begin.powershell
 #      ^ interpolated.complex.source.powershell support.function.powershell
 #                      ^ punctuation.section.group.end.powershell
@@ -1183,7 +1190,7 @@ $file = join-path $env:SystemDrive "$([System.io.path]::GetRandomFileName()).ps1
 #            ^ support.function.powershell
 #                  ^ support.variable.drive.powershell
 #                         ^ variable.other.readwrite.powershell
-#                                   ^ string.quoted.double.powershell punctuation.definition.variable.powershell
+#                                   ^ string.quoted.double.powershell punctuation.definition.substatement.powershell punctuation.section.embedded.substatement.begin.powershell
 #                                        ^ storage.type.powershell
 $ScriptBlock | Out-File $file -Force
 # <- punctuation.definition.variable.powershell
@@ -1217,7 +1224,8 @@ get-thing | Out-WithYou > $null # destroy
 #             ^^ constant.character.escape.powershell
 #                                    ^^  ^^  ^^  ^^  ^^ not:constant.character.escape.powershell
 "When you call a method: $( get-number | %{ invoke-command $( [string]::format("Like (this{0})","what?") ) $var } )"
-#                        ^                                                                                 ^ punctuation.definition.variable.powershell
+#                        ^ string.quoted.double.powershell punctuation.definition.substatement.powershell punctuation.section.embedded.substatement.begin.powershell
+#                                                                                                          ^ punctuation.definition.variable.powershell
 #                                      ^ keyword.operator.other.powershell
 #                                                           ^                 ^ meta.group.complex.subexpression.powershell punctuation.section.group.begin.powershell
 #                                                                ^ storage.type.powershell


### PR DESCRIPTION
Improve embedded substatements, fix #132.

- Rename `#interpolatedStringContent` to `#subexpression`.
- Remove include `#interpolation` from `#subexpression`.
- Change scopes in `#interpolation` to include `meta.embedded`,  `keyword.other` was
`punctuation.definition.variable`.
- Change scope in root pattern for `$( )`, `keyword.other` was
`punctuation.definition.variable`. (No tests are present for this)
- Remove redundant includes from `#subexpression` and `#interpolation`.
- Adjust test, of embedded substatements in double quoted strings.

Sample appearance
- VS Code (before):
![image](https://user-images.githubusercontent.com/26179051/63206485-d7c3fe80-c07a-11e9-8fc7-60f11c9574a9.png)

- VS Code:
![image](https://user-images.githubusercontent.com/26179051/63151988-662f7600-bfd0-11e9-86d6-cf4dddd52e66.png)

- ATOM:
![image](https://user-images.githubusercontent.com/26179051/63152022-7b0c0980-bfd0-11e9-9117-dc4449326530.png)
