### PR TITLE
Add recognition for Dispose{} named function block

### DIFF
--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -258,7 +258,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>(?&lt;!\w|-|\.)((?i:begin|break|catch|continue|data|default|define|do|dynamicparam|else|elseif|end|exit|finally|for|from|if|in|inlinescript|parallel|param|process|return|sequence|switch|throw|trap|try|until|var|while)|%|\?)(?!\w)</string>
+			<string>(?&lt;!\w|-|\.)((?i:begin|break|catch|continue|data|default|define|dispose|do|dynamicparam|else|elseif|end|exit|finally|for|from|if|in|inlinescript|parallel|param|process|return|sequence|switch|throw|trap|try|until|var|while)|%|\?)(?!\w)</string>
 			<key>name</key>
 			<string>keyword.control.powershell</string>
 		</dict>

--- a/examples/advancedFunction.ps1
+++ b/examples/advancedFunction.ps1
@@ -90,4 +90,7 @@ function Verb-Noun
     End
     {
     }
+    Dispose
+    {
+    }
 }

--- a/spec/testfiles/syntax_test_Function.ps1
+++ b/spec/testfiles/syntax_test_Function.ps1
@@ -370,4 +370,8 @@ function Verb-Noun {
     # <- keyword.control.powershell
 
     }
+    Dispose{
+    # <- keyword.control.powershell
+    }
+
 }


### PR DESCRIPTION
Adds dispose{} named block keyword to language files. Yay, editor highlighting! 🎉 

Reference https://github.com/PowerShell/PowerShell/pull/9900 for indication on when the feature will become available. From current team decisions it appears it will likely be merged post-v7 and generally available the following release.

This is all the references to named blocks I could find, and I updated an example or two while I was at it. If I missed anything, please let me know.

/cc @TylerLeonhardt 