### PR TITLE
Add #Requires -PSEdition and -Assembly

### DIFF
--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -1212,7 +1212,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>\-(?i:Modules|PSSnapin|RunAsAdministrator|ShellId|Version)</string>
+					<string>\-(?i:Modules|PSSnapin|RunAsAdministrator|ShellId|Version|Assembly|PSEdition)</string>
 					<key>name</key>
 					<string>keyword.other.powershell</string>
 				</dict>

--- a/examples/TheBigTestFile.ps1
+++ b/examples/TheBigTestFile.ps1
@@ -11,6 +11,7 @@ using namespace System.Management.Automation
 #Requires -Modules PSWorkflow,ActiveDirectory
 #Requires -ShellId MyLocalShell
 #Requires -PSEdition Core
+#Requires -Assembly System
 #Requires -Modules PSWorkflow @{
     ModuleName="PSScheduledJob"
     ModuleVersion="1.0.0.0"

--- a/examples/TheBigTestFile.ps1
+++ b/examples/TheBigTestFile.ps1
@@ -10,6 +10,7 @@ using namespace System.Management.Automation
 #Requires -Modules PSWorkflow, ActiveDirectory
 #Requires -Modules PSWorkflow,ActiveDirectory
 #Requires -ShellId MyLocalShell
+#Requires -PSEdition Core
 #Requires -Modules PSWorkflow @{
     ModuleName="PSScheduledJob"
     ModuleVersion="1.0.0.0"

--- a/spec/testfiles/syntax_test_TheBigTestFile.ps1
+++ b/spec/testfiles/syntax_test_TheBigTestFile.ps1
@@ -68,6 +68,11 @@ using namespace System.Management.Automation
 # ^ meta.requires.powershell keyword.control.requires.powershell
 #         ^^^^^^^^^^ meta.requires.powershell keyword.other.powershell
 #                    ^^^^ meta.requires.powershell variable.parameter.powershell
+#Requires -Assembly System
+# <- punctuation.definition.comment.powershell
+# ^ meta.requires.powershell keyword.control.requires.powershell
+#         ^^^^^^^^^ meta.requires.powershell keyword.other.powershell
+#                   ^^^^^^ meta.requires.powershell variable.parameter.powershell
 #Requires -Modules PSWorkflow, @{ModuleName="PSScheduledJob"; ModuleVersion="1.0.0.0"}
 # <- punctuation.definition.comment.powershell
 # ^ meta.requires.powershell keyword.control.requires.powershell

--- a/spec/testfiles/syntax_test_TheBigTestFile.ps1
+++ b/spec/testfiles/syntax_test_TheBigTestFile.ps1
@@ -63,6 +63,11 @@ using namespace System.Management.Automation
 # ^ meta.requires.powershell keyword.control.requires.powershell
 #         ^^^^^^^^ meta.requires.powershell keyword.other.powershell
 #                  ^^^^^^^^^^^^ meta.requires.powershell variable.parameter.powershell
+#Requires -PSEdition Core
+# <- punctuation.definition.comment.powershell
+# ^ meta.requires.powershell keyword.control.requires.powershell
+#         ^^^^^^^^^^ meta.requires.powershell keyword.other.powershell
+#                    ^^^^ meta.requires.powershell variable.parameter.powershell
 #Requires -Modules PSWorkflow, @{ModuleName="PSScheduledJob"; ModuleVersion="1.0.0.0"}
 # <- punctuation.definition.comment.powershell
 # ^ meta.requires.powershell keyword.control.requires.powershell


### PR DESCRIPTION
`-PSEdition` works correctly, but `-Assembly` is a bit of a cheat. It mostly looks right, but currently it matches the argument as `variable.parameter.powershells`, with a couple of exceptions:

- Assembly names can have dots in, `#Requires -Assembly System.Management.Automation`. This is true of modules too, but currently `-Modules AzureRM.Netcore` gets tokenised as two `variable.parameter.powershell`s with the dot as a `meta.requires.powershell`. It looks more or less right as is, but it's an easy enough fix.

- Assemblies can be specified by file paths, eg `#Requires -Assembly path\to\foo.dll`. The dots and path separators both get tokenised as `meta.requires.powershell`, but paths are a bit more complicated to handle. I was hoping there was already a pattern for matching a path, but nothing jumped out at me?

- Assemblies can be specified using an assembly specifier, eg `#Requires -Assembly "System.Management.Automation, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"`, which would require allowing quotes, commas, and spaces at least.