### PR TITLE
Add syntax highlighting for 'clean {}' block

### DIFF
--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -288,7 +288,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>(?&lt;!\w|-|\.)((?i:begin|break|catch|continue|data|default|define|do|dynamicparam|else|elseif|end|exit|finally|for|from|if|in|inlinescript|parallel|param|process|return|sequence|switch|throw|trap|try|until|var|while)|%|\?)(?!\w)</string>
+			<string>(?&lt;!\w|-|\.)((?i:begin|break|catch|clean|continue|data|default|define|do|dynamicparam|else|elseif|end|exit|finally|for|from|if|in|inlinescript|parallel|param|process|return|sequence|switch|throw|trap|try|until|var|while)|%|\?)(?!\w)</string>
 			<key>name</key>
 			<string>keyword.control.powershell</string>
 		</dict>

--- a/examples/advancedFunction.ps1
+++ b/examples/advancedFunction.ps1
@@ -90,4 +90,7 @@ function Verb-Noun
     End
     {
     }
+    Clean
+    {
+    }
 }

--- a/spec/testfiles/syntax_test_Function.ps1
+++ b/spec/testfiles/syntax_test_Function.ps1
@@ -370,4 +370,7 @@ function Verb-Noun {
     # <- keyword.control.powershell
 
     }
+    Clean {
+    # <- keyword.control.powershell
+    }
 }


### PR DESCRIPTION
This is a follow-up PR of #186, because of the renaming of the new named block.

```powershell
function Get-Foo {
    [CmdletBinding()]
    param()

    begin { }
    process { }
    end { }
    clean { }
}
```

Reference https://github.com/PowerShell/PowerShell/pull/15177 for indication on when the feature will become available.
https://github.com/PowerShell/PowerShell/pull/15177 did some design changes based on the original PR PowerShell/PowerShell#9900