### PR TITLE
Fix PowerShell highlighting of built-in constant variables

### DIFF
--- a/PowerShellSyntax.tmLanguage
+++ b/PowerShellSyntax.tmLanguage
@@ -1007,7 +1007,7 @@
 						<key>0</key>
 						<dict>
 							<key>name</key>
-							<string>support.constant.variable.powershell</string>
+							<string>variable.other.constant.powershell</string>
 						</dict>
 						<key>1</key>
 						<dict>
@@ -1291,7 +1291,7 @@
 						<key>0</key>
 						<dict>
 							<key>name</key>
-							<string>support.constant.variable.powershell</string>
+							<string>variable.other.constant.powershell</string>
 						</dict>
 						<key>1</key>
 						<dict>


### PR DESCRIPTION
Related VSCode PR: <https://github.com/microsoft/vscode/pull/298570>

# PR Summary

Use a TextMate scope for PowerShell built-in constant variables that most themes actually have defined in `tokenColors`.

I see that C#, Ruby and Go TextMate files uses `variable.other.constant.<language>`, so I went with that.

* <https://github.com/search?q=repo%3Amicrosoft%2Fvscode%20variable.other.constant.&type=code>

## PR Context

For a long time, PowerShell highlighting for built-in constant variables has been broken in VSCode.

<img width="652" height="751" alt="image" src="https://github.com/user-attachments/assets/bd71d2de-5171-4e67-9d11-647c490969ee" />

Some related issues:

* 2024-03-16: <https://github.com/PowerShell/vscode-powershell/issues/4944>
* 2024-03-17: <https://github.com/PowerShell/EditorSyntax/issues/218>
* 2025-04-03: <https://github.com/PowerShell/vscode-powershell/issues/5166>

I believe I've tracked it down to the PowerShell TextMate using a TextMate scope most themes does not have a definition for:

<img width="1243" height="976" alt="image" src="https://github.com/user-attachments/assets/8340fdf3-eae9-405b-b542-159d918d0b40" />

The official Dracula theme even have a workaround just for this <https://github.com/dracula/visual-studio-code/blob/main/src/dracula.yml>:

```yml
  - name: Powershell constants mistakenly scoped to `support`, rather than `constant` (edge)
    scope:
    - support.constant
    settings:
      fontStyle: normal
      foreground: *PURPLE
```

